### PR TITLE
feat(api): add idempotent database seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,39 @@ TBD
 ## Getting Started
 
 TBD
+
+## Database
+
+### Seeding
+
+Populate the database with sample doctors, patients, appointments, consultation records, prescriptions, and notifications:
+
+```bash
+# From the repo root
+pnpm seed
+
+# Or from apps/api
+pnpm run seed
+```
+
+The seed script is **idempotent** — it wipes all existing data and re-creates it from scratch, so it is safe to run repeatedly.
+
+### Reset & Re-seed
+
+To drop all tables, re-run migrations, and re-seed in one command:
+
+```bash
+npx prisma migrate reset --schema apps/api/prisma/schema.prisma
+```
+
+### Seed Data Summary
+
+| Entity              | Count | Notes                                           |
+| ------------------- | ----- | ----------------------------------------------- |
+| Doctors             | 7     | Varied specializations, complete profiles       |
+| Patients            | 4     | Realistic name, DOB, weight, height, history    |
+| Availability Slots  | ~100  | Open + blocked slots across the next 14 days    |
+| Appointments        | 6     | 3 confirmed (future) + 3 completed (past)       |
+| Consultation Records| 3     | Attached to completed appointments              |
+| Prescriptions       | ~5    | 1–3 per consultation record                     |
+| Notifications       | ~15   | Mix of read/unread for doctors and patients      |

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,11 @@
     "dev": "nest start --watch",
     "build": "nest build",
     "start": "node dist/main",
-    "lint": "eslint src --ext .ts"
+    "lint": "eslint src --ext .ts",
+    "seed": "tsx prisma/seed.ts"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
     "@lunasol/types": "workspace:*",
@@ -26,6 +30,7 @@
     "@types/pg": "^8.11.11",
     "dotenv": "^16.4.7",
     "prisma": "^7.8.0",
+    "tsx": "^4.22.3",
     "typescript": "^5.8.3"
   }
 }

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,0 +1,483 @@
+import 'dotenv/config';
+import {
+  PrismaClient,
+  Role,
+  AppointmentStatus,
+} from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import pg from 'pg';
+
+const pool = new pg.Pool({ connectionString: process.env['DATABASE_URL'] });
+const adapter = new PrismaPg(pool);
+const prisma = new PrismaClient({ adapter });
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Return a Date offset by `days` from today at the given hour (UTC). */
+function futureDate(days: number, hour: number): Date {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  d.setUTCHours(hour, 0, 0, 0);
+  return d;
+}
+
+/** Return a Date offset by negative `days` from today at the given hour. */
+function pastDate(days: number, hour: number): Date {
+  return futureDate(-days, hour);
+}
+
+// ─── Seed Data Definitions ────────────────────────────────────────────────────
+
+const DOCTORS = [
+  {
+    clerkId: 'clerk_seed_doctor_1',
+    email: 'dr.santos@lunasol.dev',
+    name: 'Dr. Maria Santos',
+    specialization: 'General Practice',
+    bio: 'Board-certified family medicine physician with 12 years of experience in primary care, preventive medicine, and chronic disease management.',
+    contactDetails: '+63 917 123 4001',
+  },
+  {
+    clerkId: 'clerk_seed_doctor_2',
+    email: 'dr.reyes@lunasol.dev',
+    name: 'Dr. Carlos Reyes',
+    specialization: 'Cardiology',
+    bio: 'Interventional cardiologist specializing in heart failure, arrhythmia management, and preventive cardiology. Fellow of the Philippine Heart Association.',
+    contactDetails: '+63 917 123 4002',
+  },
+  {
+    clerkId: 'clerk_seed_doctor_3',
+    email: 'dr.lim@lunasol.dev',
+    name: 'Dr. Angela Lim',
+    specialization: 'Dermatology',
+    bio: 'Dermatologist with expertise in acne treatment, cosmetic dermatology, and skin cancer screening. Published researcher in tropical skin disorders.',
+    contactDetails: '+63 917 123 4003',
+  },
+  {
+    clerkId: 'clerk_seed_doctor_4',
+    email: 'dr.garcia@lunasol.dev',
+    name: 'Dr. Jose Garcia',
+    specialization: 'Pediatrics',
+    bio: 'Pediatrician dedicated to newborn care, childhood immunizations, and developmental assessments. 15 years of clinical experience.',
+    contactDetails: '+63 917 123 4004',
+  },
+  {
+    clerkId: 'clerk_seed_doctor_5',
+    email: 'dr.navarro@lunasol.dev',
+    name: 'Dr. Patricia Navarro',
+    specialization: 'Neurology',
+    bio: 'Neurologist focused on headache disorders, epilepsy, and neurodegenerative diseases. Trained at the Philippine General Hospital.',
+    contactDetails: '+63 917 123 4005',
+  },
+  {
+    clerkId: 'clerk_seed_doctor_6',
+    email: 'dr.dela-cruz@lunasol.dev',
+    name: 'Dr. Ramon dela Cruz',
+    specialization: 'Psychiatry',
+    bio: 'Psychiatrist providing evidence-based treatment for anxiety, depression, ADHD, and trauma-related disorders. Advocate for mental health awareness.',
+    contactDetails: '+63 917 123 4006',
+  },
+  {
+    clerkId: 'clerk_seed_doctor_7',
+    email: 'dr.villanueva@lunasol.dev',
+    name: 'Dr. Sofia Villanueva',
+    specialization: 'Orthopedics',
+    bio: 'Orthopedic surgeon specializing in sports medicine, joint replacement, and minimally-invasive arthroscopic surgery.',
+    contactDetails: '+63 917 123 4007',
+  },
+];
+
+const PATIENTS = [
+  {
+    clerkId: 'clerk_seed_patient_1',
+    email: 'juan.bautista@example.com',
+    name: 'Juan Bautista',
+    birthday: new Date('1990-03-15'),
+    weight: 72.5,
+    height: 170,
+    phone: '+63 918 555 0001',
+    address: '123 Rizal Ave, Makati City',
+    medicalHistory: 'Mild asthma diagnosed in childhood. Seasonal allergies. No surgical history.',
+  },
+  {
+    clerkId: 'clerk_seed_patient_2',
+    email: 'anna.cruz@example.com',
+    name: 'Anna Cruz',
+    birthday: new Date('1985-07-22'),
+    weight: 58.0,
+    height: 160,
+    phone: '+63 918 555 0002',
+    address: '456 Bonifacio St, Quezon City',
+    medicalHistory: 'Type 2 diabetes managed with metformin since 2019. Hypertension controlled with losartan.',
+  },
+  {
+    clerkId: 'clerk_seed_patient_3',
+    email: 'miguel.torres@example.com',
+    name: 'Miguel Torres',
+    birthday: new Date('1998-11-08'),
+    weight: 80.0,
+    height: 178,
+    phone: '+63 918 555 0003',
+    address: '789 Mabini Blvd, Pasig City',
+    medicalHistory: 'No known chronic conditions. Appendectomy at age 16. Penicillin allergy.',
+  },
+  {
+    clerkId: 'clerk_seed_patient_4',
+    email: 'rosa.mendoza@example.com',
+    name: 'Rosa Mendoza',
+    birthday: new Date('1975-01-30'),
+    weight: 65.0,
+    height: 155,
+    phone: '+63 918 555 0004',
+    address: '321 Luna St, Mandaluyong City',
+    medicalHistory: 'Hypothyroidism on levothyroxine. History of migraine with aura. Cholecystectomy in 2018.',
+  },
+];
+
+// ─── Main Seed Function ───────────────────────────────────────────────────────
+
+async function main() {
+  console.log('🌱 Seeding database …');
+
+  // ── 1. Clean slate (reverse FK order) ────────────────────────────────────
+  console.log('  ✕ Clearing existing data …');
+  await prisma.notification.deleteMany();
+  await prisma.prescription.deleteMany();
+  await prisma.consultationRecord.deleteMany();
+  await prisma.appointment.deleteMany();
+  await prisma.availabilitySlot.deleteMany();
+  await prisma.patientProfile.deleteMany();
+  await prisma.doctorProfile.deleteMany();
+  await prisma.user.deleteMany();
+
+  // ── 2. Create doctor users + profiles ────────────────────────────────────
+  console.log('  + Creating doctors …');
+  const doctorProfiles = [];
+  for (const doc of DOCTORS) {
+    const user = await prisma.user.create({
+      data: {
+        clerkId: doc.clerkId,
+        email: doc.email,
+        role: Role.DOCTOR,
+        doctor: {
+          create: {
+            name: doc.name,
+            specialization: doc.specialization,
+            bio: doc.bio,
+            contactDetails: doc.contactDetails,
+          },
+        },
+      },
+      include: { doctor: true },
+    });
+    doctorProfiles.push(user.doctor!);
+  }
+
+  // ── 3. Create patient users + profiles ───────────────────────────────────
+  console.log('  + Creating patients …');
+  const patientProfiles = [];
+  for (const pat of PATIENTS) {
+    const user = await prisma.user.create({
+      data: {
+        clerkId: pat.clerkId,
+        email: pat.email,
+        role: Role.PATIENT,
+        patient: {
+          create: {
+            name: pat.name,
+            birthday: pat.birthday,
+            weight: pat.weight,
+            height: pat.height,
+            phone: pat.phone,
+            address: pat.address,
+            medicalHistory: pat.medicalHistory,
+          },
+        },
+      },
+      include: { patient: true },
+    });
+    patientProfiles.push(user.patient!);
+  }
+
+  // ── 4. Create availability slots ─────────────────────────────────────────
+  console.log('  + Creating availability slots …');
+  const allSlots: Awaited<ReturnType<typeof prisma.availabilitySlot.create>>[] = [];
+
+  for (const doctor of doctorProfiles) {
+    // Create slots for the next 14 days
+    for (let day = 1; day <= 14; day++) {
+      const hours = [9, 10, 11, 14, 15]; // 5 slots per day
+      for (const hour of hours) {
+        const slot = await prisma.availabilitySlot.create({
+          data: {
+            doctorId: doctor.id,
+            startTime: futureDate(day, hour),
+            endTime: futureDate(day, hour + 1),
+            isBlocked: false,
+          },
+        });
+        allSlots.push(slot);
+      }
+
+      // 1 blocked slot per day (e.g. lunch break or personal time)
+      const blockedSlot = await prisma.availabilitySlot.create({
+        data: {
+          doctorId: doctor.id,
+          startTime: futureDate(day, 12),
+          endTime: futureDate(day, 13),
+          isBlocked: true,
+        },
+      });
+      allSlots.push(blockedSlot);
+    }
+  }
+
+  // Also create a few past slots for completed appointments
+  const pastSlots = [];
+  for (let i = 0; i < 3; i++) {
+    const slot = await prisma.availabilitySlot.create({
+      data: {
+        doctorId: doctorProfiles[i]!.id,
+        startTime: pastDate(7 - i, 10),
+        endTime: pastDate(7 - i, 11),
+        isBlocked: false,
+      },
+    });
+    pastSlots.push(slot);
+  }
+
+  // ── 5. Create confirmed appointments (future) ───────────────────────────
+  console.log('  + Creating confirmed appointments …');
+
+  // Find open future slots for first 3 doctors (take 1st available slot each)
+  const confirmedAppointments = [];
+  for (let i = 0; i < 3; i++) {
+    const doctorSlots = allSlots.filter(
+      (s) => s.doctorId === doctorProfiles[i]!.id && !s.isBlocked,
+    );
+    const slot = doctorSlots[0]!;
+
+    const appointment = await prisma.appointment.create({
+      data: {
+        patientId: patientProfiles[i]!.id,
+        doctorId: doctorProfiles[i]!.id,
+        slotId: slot.id,
+        status: AppointmentStatus.CONFIRMED,
+        jitsiRoom: `lunasol-${doctorProfiles[i]!.id.slice(-6)}-${patientProfiles[i]!.id.slice(-6)}`,
+      },
+    });
+    confirmedAppointments.push(appointment);
+  }
+
+  // ── 6. Create completed appointments (past) + consultation records ──────
+  console.log('  + Creating completed appointments with records …');
+
+  const consultationData = [
+    {
+      notes:
+        'Patient presented with persistent dry cough for 2 weeks. Lungs clear on auscultation. Likely post-nasal drip secondary to allergic rhinitis. Advised saline nasal rinse and follow-up in 2 weeks if symptoms persist.',
+      prescriptions: [
+        {
+          medicationName: 'Cetirizine',
+          dosage: '10mg',
+          frequency: 'Once daily at bedtime',
+          duration: '14 days',
+          notes: 'Take with water. May cause drowsiness.',
+        },
+        {
+          medicationName: 'Fluticasone Nasal Spray',
+          dosage: '50mcg/spray, 2 sprays per nostril',
+          frequency: 'Once daily in the morning',
+          duration: '30 days',
+          notes: 'Shake well before use. Avoid spraying towards nasal septum.',
+        },
+      ],
+    },
+    {
+      notes:
+        'Routine cardiac follow-up. Blood pressure 130/85 mmHg. ECG shows normal sinus rhythm. Lipid panel results reviewed — LDL slightly elevated at 140 mg/dL. Lifestyle modifications discussed. Consider statin therapy at next visit if no improvement.',
+      prescriptions: [
+        {
+          medicationName: 'Losartan',
+          dosage: '50mg',
+          frequency: 'Once daily in the morning',
+          duration: '90 days',
+          notes: 'Continue current dose. Monitor blood pressure weekly.',
+        },
+      ],
+    },
+    {
+      notes:
+        'Patient reports facial acne flare-up over the past month, primarily on forehead and chin. No cystic lesions observed. Mild comedonal and papular acne. Skin otherwise well-hydrated. Prescribed topical retinoid and gentle cleanser routine.',
+      prescriptions: [
+        {
+          medicationName: 'Adapalene Gel 0.1%',
+          dosage: 'Pea-sized amount',
+          frequency: 'Once daily at bedtime',
+          duration: '60 days',
+          notes: 'Apply to clean, dry skin. Use sunscreen during the day — increased photosensitivity.',
+        },
+        {
+          medicationName: 'Benzoyl Peroxide 2.5% Wash',
+          dosage: 'As directed',
+          frequency: 'Once daily in the morning',
+          duration: '60 days',
+          notes: 'Lather on affected areas for 1–2 minutes, then rinse.',
+        },
+      ],
+    },
+  ];
+
+  for (let i = 0; i < 3; i++) {
+    const appointment = await prisma.appointment.create({
+      data: {
+        patientId: patientProfiles[i]!.id,
+        doctorId: doctorProfiles[i]!.id,
+        slotId: pastSlots[i]!.id,
+        status: AppointmentStatus.COMPLETED,
+        jitsiRoom: `lunasol-past-${i + 1}`,
+        record: {
+          create: {
+            notes: consultationData[i]!.notes,
+            prescriptions: {
+              create: consultationData[i]!.prescriptions,
+            },
+          },
+        },
+      },
+    });
+  }
+
+  // ── 7. Create notifications ──────────────────────────────────────────────
+  console.log('  + Creating notifications …');
+
+  // Fetch all users for notification recipients
+  const allUsers = await prisma.user.findMany();
+  const doctorUsers = allUsers.filter((u) => u.role === Role.DOCTOR);
+  const patientUsers = allUsers.filter((u) => u.role === Role.PATIENT);
+
+  const notifications = [
+    // Patient notifications
+    {
+      recipientId: patientUsers[0]!.id,
+      type: 'APPOINTMENT_CONFIRMED',
+      message: `Your appointment with ${DOCTORS[0]!.name} has been confirmed.`,
+      isRead: false,
+    },
+    {
+      recipientId: patientUsers[0]!.id,
+      type: 'CONSULTATION_COMPLETE',
+      message: `${DOCTORS[0]!.name} has completed your consultation. View your records and prescriptions.`,
+      isRead: true,
+    },
+    {
+      recipientId: patientUsers[0]!.id,
+      type: 'PRESCRIPTION_ISSUED',
+      message: 'A new prescription has been issued for you. Check your medical records.',
+      isRead: true,
+    },
+    {
+      recipientId: patientUsers[1]!.id,
+      type: 'APPOINTMENT_CONFIRMED',
+      message: `Your appointment with ${DOCTORS[1]!.name} has been confirmed.`,
+      isRead: false,
+    },
+    {
+      recipientId: patientUsers[1]!.id,
+      type: 'APPOINTMENT_REMINDER',
+      message: 'Reminder: You have an upcoming appointment tomorrow at 10:00 AM.',
+      isRead: false,
+    },
+    {
+      recipientId: patientUsers[2]!.id,
+      type: 'APPOINTMENT_CONFIRMED',
+      message: `Your appointment with ${DOCTORS[2]!.name} has been confirmed.`,
+      isRead: true,
+    },
+    {
+      recipientId: patientUsers[2]!.id,
+      type: 'CONSULTATION_COMPLETE',
+      message: `${DOCTORS[2]!.name} has completed your consultation. View your records and prescriptions.`,
+      isRead: false,
+    },
+    {
+      recipientId: patientUsers[3]!.id,
+      type: 'WELCOME',
+      message: 'Welcome to LunaSol! Discover doctors and book your first consultation.',
+      isRead: true,
+    },
+
+    // Doctor notifications
+    {
+      recipientId: doctorUsers[0]!.id,
+      type: 'NEW_APPOINTMENT',
+      message: `New appointment booked by ${PATIENTS[0]!.name}.`,
+      isRead: true,
+    },
+    {
+      recipientId: doctorUsers[0]!.id,
+      type: 'APPOINTMENT_REMINDER',
+      message: 'Reminder: You have 2 appointments scheduled for tomorrow.',
+      isRead: false,
+    },
+    {
+      recipientId: doctorUsers[1]!.id,
+      type: 'NEW_APPOINTMENT',
+      message: `New appointment booked by ${PATIENTS[1]!.name}.`,
+      isRead: false,
+    },
+    {
+      recipientId: doctorUsers[2]!.id,
+      type: 'NEW_APPOINTMENT',
+      message: `New appointment booked by ${PATIENTS[2]!.name}.`,
+      isRead: true,
+    },
+    {
+      recipientId: doctorUsers[3]!.id,
+      type: 'WELCOME',
+      message: 'Welcome to LunaSol! Set up your availability to start accepting patients.',
+      isRead: false,
+    },
+    {
+      recipientId: doctorUsers[4]!.id,
+      type: 'WELCOME',
+      message: 'Welcome to LunaSol! Set up your availability to start accepting patients.',
+      isRead: false,
+    },
+    {
+      recipientId: doctorUsers[5]!.id,
+      type: 'WELCOME',
+      message: 'Welcome to LunaSol! Set up your availability to start accepting patients.',
+      isRead: true,
+    },
+  ];
+
+  await prisma.notification.createMany({ data: notifications });
+
+  // ── Done ─────────────────────────────────────────────────────────────────
+  const counts = {
+    users: await prisma.user.count(),
+    doctorProfiles: await prisma.doctorProfile.count(),
+    patientProfiles: await prisma.patientProfile.count(),
+    availabilitySlots: await prisma.availabilitySlot.count(),
+    appointments: await prisma.appointment.count(),
+    consultationRecords: await prisma.consultationRecord.count(),
+    prescriptions: await prisma.prescription.count(),
+    notifications: await prisma.notification.count(),
+  };
+
+  console.log('\n✅ Seed complete!');
+  console.log('   Records created:');
+  for (const [table, count] of Object.entries(counts)) {
+    console.log(`     ${table}: ${count}`);
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error('❌ Seed failed:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "turbo dev",
     "build": "turbo build",
     "lint": "turbo lint",
-    "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\" --ignore-path .gitignore"
+    "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\" --ignore-path .gitignore",
+    "seed": "pnpm --filter @lunasol/api seed"
   },
   "dependencies": {
     "@prisma/client": "^7.8.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       prisma:
         specifier: ^7.8.0
         version: 7.8.0(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -176,6 +179,162 @@ packages:
 
   '@electric-sql/pglite@0.4.1':
     resolution: {integrity: sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -1244,6 +1403,11 @@ packages:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1409,6 +1573,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -2281,6 +2450,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo@2.9.14:
     resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
@@ -2469,6 +2643,84 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
 
   '@electric-sql/pglite@0.4.1': {}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
     dependencies:
@@ -3571,6 +3823,35 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -3793,6 +4074,9 @@ snapshots:
   fs-monkey@1.1.0: {}
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -4574,6 +4858,12 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   turbo@2.9.14:
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,5 @@ packages:
 allowBuilds:
   '@nestjs/core': true
   '@prisma/engines': true
+  esbuild: true
   prisma: true


### PR DESCRIPTION
Closes #4

## Summary

Adds a comprehensive, idempotent database seed script at `apps/api/prisma/seed.ts` that populates the dev database with realistic sample data.

### Seed Data

| Entity | Count | Details |
|---|---|---|
| Doctors | 7 | General Practice, Cardiology, Dermatology, Pediatrics, Neurology, Psychiatry, Orthopedics |
| Patients | 4 | Complete profiles with name, DOB, weight, height, medical history |
| Availability Slots | ~590 | 5 open + 1 blocked slot per doctor per day across 14 days, plus 3 past slots |
| Appointments | 6 | 3 confirmed (future) + 3 completed (past) |
| Consultation Records | 3 | Attached to completed appointments with clinical notes |
| Prescriptions | 5 | 1–2 per consultation record |
| Notifications | 15 | Mix of read/unread across doctors and patients |

### Changes

- **`apps/api/prisma/seed.ts`** — New seed script using PrismaPg driver adapter
- **`apps/api/package.json`** — Add `prisma.seed` config + `seed` script + `tsx` devDep
- **`package.json`** (root) — Add `pnpm seed` convenience script
- **`pnpm-workspace.yaml`** — Allow esbuild builds (tsx dependency)
- **`README.md`** — Document seed and reset/re-seed instructions

### How to run

```bash
# From repo root
pnpm seed

# Or from apps/api
pnpm run seed
```

### Test plan

- [x] `pnpm seed` populates the database successfully
- [x] Running seed twice produces identical counts (idempotent)
- [x] `pnpm run build` passes for all packages
- [x] `npx prisma validate` passes