### PR TITLE
feat(infra): production deployment with Cloudflare Tunnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
 CLERK_SECRET_KEY=sk_test_...
 CLERK_WEBHOOK_SECRET=whsec_...
 
+# ── Cloudflare Tunnel ─────────────────────────────────────────────────────────
+CLOUDFLARE_TUNNEL_TOKEN=
+
 # ── App ports (override if needed) ────────────────────────────────────────────
 WEB_PORT=3000
 API_PORT=3001

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,36 +7,22 @@ on:
 
 jobs:
   deploy:
-    name: SSH deploy
-    runs-on: ubuntu-latest
+    name: Local deploy
+    runs-on: self-hosted
     environment: production
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script: |
-            set -e
+      - name: Build images
+        run: docker compose -f docker-compose.prod.yml build
 
-            cd ${{ secrets.DEPLOY_PATH }}
+      - name: Start containers
+        run: docker compose -f docker-compose.prod.yml up -d --remove-orphans
 
-            git pull origin prod
+      - name: Run migrations
+        run: docker compose -f docker-compose.prod.yml exec -T api npx prisma migrate deploy
 
-            # Build new images without taking down the running stack
-            docker compose -f docker-compose.prod.yml build
-
-            # Bring up the new images; old containers stay until replaced
-            docker compose -f docker-compose.prod.yml up -d --remove-orphans
-
-            # Run migrations against the live DB after new containers are healthy
-            docker compose -f docker-compose.prod.yml exec -T api \
-              npx prisma migrate deploy
-
-            # Clean up dangling images
-            docker image prune -f
+      - name: Prune old images
+        run: docker image prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,17 @@ Thumbs.db
 .windsurf/
 .copilot/
 .aider*
+.agents/
+
+# Turbo
+.turbo/
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+.venv/
+venv/
 
 # Local/private files — exclude hackathon brief but track planning docs
 planning

--- a/apps/ai/Dockerfile.prod
+++ b/apps/ai/Dockerfile.prod
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/ai/Dockerfile.prod
+++ b/apps/ai/Dockerfile.prod
@@ -2,6 +2,7 @@ FROM python:3.12-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/apps/api/Dockerfile.prod
+++ b/apps/api/Dockerfile.prod
@@ -16,6 +16,7 @@ COPY packages/types ./packages/types
 COPY apps/api ./apps/api
 
 WORKDIR /app/apps/api
+RUN /app/node_modules/.bin/prisma generate
 RUN pnpm build
 
 FROM node:22-alpine AS runner

--- a/apps/api/Dockerfile.prod
+++ b/apps/api/Dockerfile.prod
@@ -1,0 +1,42 @@
+FROM node:22-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+ENV PNPM_CONFIG_TRUST_LOCKFILE=true
+
+WORKDIR /app
+
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/api/package.json ./apps/api/
+COPY packages/types/package.json ./packages/types/
+
+RUN pnpm install --frozen-lockfile
+
+COPY tsconfig.base.json ./
+COPY packages/types ./packages/types
+COPY apps/api ./apps/api
+
+WORKDIR /app/apps/api
+RUN pnpm build
+
+FROM node:22-alpine AS runner
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+ENV PNPM_CONFIG_TRUST_LOCKFILE=true
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/api/package.json ./apps/api/
+COPY packages/types/package.json ./packages/types/
+
+RUN pnpm install --frozen-lockfile --prod
+
+COPY --from=builder /app/apps/api/dist ./apps/api/dist
+COPY apps/api/prisma ./apps/api/prisma
+COPY packages/types ./packages/types
+
+WORKDIR /app/apps/api
+
+EXPOSE 3001
+CMD ["sh", "-c", "/app/node_modules/.bin/prisma generate && node dist/main"]

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -33,7 +33,6 @@ COPY packages/types/package.json ./packages/types/
 RUN pnpm install --frozen-lockfile --prod
 
 COPY --from=builder /app/apps/web/.next ./apps/web/.next
-COPY --from=builder /app/apps/web/public ./apps/web/public
 COPY packages/types ./packages/types
 
 WORKDIR /app/apps/web

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -1,0 +1,42 @@
+FROM node:22-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+ENV PNPM_CONFIG_TRUST_LOCKFILE=true
+
+WORKDIR /app
+
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/web/package.json ./apps/web/
+COPY packages/types/package.json ./packages/types/
+
+RUN pnpm install --frozen-lockfile
+
+COPY tsconfig.base.json ./
+COPY packages/types ./packages/types
+COPY apps/web ./apps/web
+
+WORKDIR /app/apps/web
+RUN pnpm build
+
+FROM node:22-alpine AS runner
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+ENV PNPM_CONFIG_TRUST_LOCKFILE=true
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY apps/web/package.json ./apps/web/
+COPY packages/types/package.json ./packages/types/
+
+RUN pnpm install --frozen-lockfile --prod
+
+COPY --from=builder /app/apps/web/.next ./apps/web/.next
+COPY --from=builder /app/apps/web/public ./apps/web/public
+COPY packages/types ./packages/types
+
+WORKDIR /app/apps/web
+
+EXPOSE 3000
+CMD ["pnpm", "start"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,6 +64,8 @@ services:
     image: nginx:alpine
     container_name: lunasol-prod-nginx
     restart: unless-stopped
+    ports:
+      - "127.0.0.1:80:80"
     volumes:
       - ./nginx/prod.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
@@ -79,10 +81,9 @@ services:
     command: tunnel --no-autoupdate run
     environment:
       - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+    network_mode: host
     depends_on:
       - nginx
-    networks:
-      - lunasol
 
 volumes:
   postgres_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,8 +64,6 @@ services:
     image: nginx:alpine
     container_name: lunasol-prod-nginx
     restart: unless-stopped
-    ports:
-      - "127.0.0.1:80:80"
     volumes:
       - ./nginx/prod.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
@@ -78,12 +76,13 @@ services:
     image: cloudflare/cloudflared:latest
     container_name: lunasol-prod-cloudflared
     restart: unless-stopped
-    command: tunnel --no-autoupdate run
+    command: tunnel --no-autoupdate run --url http://nginx:80
     environment:
       - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
-    network_mode: host
     depends_on:
       - nginx
+    networks:
+      - lunasol
 
 volumes:
   postgres_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,86 @@
+name: lunasol-prod
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile.prod
+    restart: unless-stopped
+    environment:
+      - NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+    depends_on:
+      - api
+    networks:
+      - lunasol
+
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile.prod
+    restart: unless-stopped
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - CLERK_SECRET_KEY=${CLERK_SECRET_KEY}
+      - CLERK_WEBHOOK_SECRET=${CLERK_WEBHOOK_SECRET}
+      - NODE_ENV=production
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - lunasol
+
+  ai:
+    build:
+      context: apps/ai
+      dockerfile: Dockerfile.prod
+    restart: unless-stopped
+    environment:
+      - PYTHONUNBUFFERED=1
+    networks:
+      - lunasol
+
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - lunasol
+
+  nginx:
+    image: nginx:alpine
+    restart: unless-stopped
+    volumes:
+      - ./nginx/prod.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - web
+      - api
+    networks:
+      - lunasol
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+    depends_on:
+      - nginx
+    networks:
+      - lunasol
+
+volumes:
+  postgres_data:
+
+networks:
+  lunasol:
+    driver: bridge

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: .
       dockerfile: apps/web/Dockerfile.prod
+    container_name: lunasol-prod-web
     restart: unless-stopped
     environment:
       - NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
@@ -17,6 +18,7 @@ services:
     build:
       context: .
       dockerfile: apps/api/Dockerfile.prod
+    container_name: lunasol-prod-api
     restart: unless-stopped
     environment:
       - DATABASE_URL=${DATABASE_URL}
@@ -33,6 +35,7 @@ services:
     build:
       context: apps/ai
       dockerfile: Dockerfile.prod
+    container_name: lunasol-prod-ai
     restart: unless-stopped
     environment:
       - PYTHONUNBUFFERED=1
@@ -41,6 +44,7 @@ services:
 
   db:
     image: postgres:16-alpine
+    container_name: lunasol-prod-db
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
@@ -58,6 +62,7 @@ services:
 
   nginx:
     image: nginx:alpine
+    container_name: lunasol-prod-nginx
     restart: unless-stopped
     volumes:
       - ./nginx/prod.conf:/etc/nginx/conf.d/default.conf:ro
@@ -69,6 +74,7 @@ services:
 
   cloudflared:
     image: cloudflare/cloudflared:latest
+    container_name: lunasol-prod-cloudflared
     restart: unless-stopped
     command: tunnel --no-autoupdate run
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
   nginx:
     image: nginx:alpine
     ports:
-      - "80:80"
+      - "81:80"
     volumes:
       - ./nginx/dev.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:

--- a/nginx/prod.conf
+++ b/nginx/prod.conf
@@ -1,0 +1,31 @@
+resolver 127.0.0.11 valid=10s;
+
+server {
+    listen 80;
+
+    location /api {
+        set $upstream_api api:3001;
+        proxy_pass http://$upstream_api;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location / {
+        set $upstream_web web:3000;
+        proxy_pass http://$upstream_web;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds production Dockerfiles (multi-stage builds) for web, api, and ai services
- Adds `docker-compose.prod.yml` with `cloudflared` for Cloudflare Tunnel ingress — no open ports required
- Adds `nginx/prod.conf` for internal reverse proxy routing
- Switches GitHub Actions deploy to self-hosted runner, removing SSH dependency
- Moves dev nginx to port 81 to avoid conflict with prod on port 80

## Deployment
- Tunnel: `lunasol.bennygil.me` → Cloudflare Edge → `cloudflared` → `nginx:80` → services
- Deploy trigger: push to `prod` branch → self-hosted runner runs `docker compose -f docker-compose.prod.yml up -d --build`