### PR TITLE
feat(web): landing page

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@lunasol/types": "workspace:*",
+    "lucide-react": "^1.16.0",
     "next": "14.2.29",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,17 +1,74 @@
 export default function Home() {
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        minHeight: '100vh',
-        fontFamily: 'sans-serif',
-      }}
-    >
-      <h1>Welcome to LunaSol Telehealth</h1>
-      <p>Your workspace is running successfully.</p>
+    <div style={{ fontFamily: "'Segoe UI', system-ui, sans-serif", background: '#0a0f1e', minHeight: '100vh', color: '#e8eaf0' }}>
+
+      {/* Nav */}
+      <nav style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '24px 48px', borderBottom: '1px solid #1e2740' }}>
+        <span style={{ fontSize: '22px', fontWeight: 700, background: 'linear-gradient(135deg, #7c9fff, #c084fc)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
+          LunaSol
+        </span>
+        <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
+          <a href="#" style={{ color: '#9aa5c4', textDecoration: 'none', fontSize: '15px' }}>Features</a>
+          <a href="#" style={{ color: '#9aa5c4', textDecoration: 'none', fontSize: '15px' }}>About</a>
+          <button style={{ background: 'transparent', border: '1px solid #3b4f7a', color: '#9aa5c4', padding: '8px 20px', borderRadius: '8px', cursor: 'pointer', fontSize: '14px' }}>
+            Sign in
+          </button>
+        </div>
+      </nav>
+
+      {/* Hero */}
+      <section style={{ textAlign: 'center', padding: '100px 24px 80px' }}>
+        <div style={{ display: 'inline-block', background: '#111827', border: '1px solid #1e2740', borderRadius: '999px', padding: '6px 16px', fontSize: '13px', color: '#7c9fff', marginBottom: '28px' }}>
+          Telehealth · AI-Assisted Care
+        </div>
+        <h1 style={{ fontSize: 'clamp(36px, 6vw, 72px)', fontWeight: 800, lineHeight: 1.1, margin: '0 auto 24px', maxWidth: '800px', background: 'linear-gradient(160deg, #ffffff 40%, #7c9fff)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
+          Healthcare, reimagined with AI
+        </h1>
+        <p style={{ fontSize: '18px', color: '#9aa5c4', maxWidth: '520px', margin: '0 auto 48px', lineHeight: 1.7 }}>
+          Connect with your care team, get AI-powered insights, and manage your health — all in one place.
+        </p>
+        <div style={{ display: 'flex', gap: '16px', justifyContent: 'center', flexWrap: 'wrap' }}>
+          <button style={{ background: 'linear-gradient(135deg, #7c9fff, #c084fc)', border: 'none', color: '#fff', padding: '14px 32px', borderRadius: '10px', fontSize: '16px', fontWeight: 600, cursor: 'pointer' }}>
+            Get started
+          </button>
+          <button style={{ background: 'transparent', border: '1px solid #3b4f7a', color: '#9aa5c4', padding: '14px 32px', borderRadius: '10px', fontSize: '16px', cursor: 'pointer' }}>
+            Learn more
+          </button>
+        </div>
+      </section>
+
+      {/* Feature cards */}
+      <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '24px', maxWidth: '1100px', margin: '0 auto', padding: '0 24px 100px' }}>
+        {[
+          { icon: '🩺', title: 'Virtual Consultations', desc: 'Connect with licensed providers from home via secure video or chat.' },
+          { icon: '🤖', title: 'AI Health Assistant', desc: 'Get instant answers and triage guidance powered by our AI model.' },
+          { icon: '📋', title: 'Health Records', desc: 'All your records, prescriptions, and history in one secure place.' },
+          { icon: '🔔', title: 'Smart Reminders', desc: 'Never miss a medication, appointment, or follow-up.' },
+        ].map(({ icon, title, desc }) => (
+          <div key={title} style={{ background: '#111827', border: '1px solid #1e2740', borderRadius: '16px', padding: '32px 28px' }}>
+            <div style={{ fontSize: '32px', marginBottom: '16px' }}>{icon}</div>
+            <h3 style={{ fontSize: '17px', fontWeight: 700, marginBottom: '10px', color: '#e8eaf0' }}>{title}</h3>
+            <p style={{ fontSize: '14px', color: '#6b7a99', lineHeight: 1.6, margin: 0 }}>{desc}</p>
+          </div>
+        ))}
+      </section>
+
+      {/* CTA banner */}
+      <section style={{ background: 'linear-gradient(135deg, #0d1a3a, #1a0d3a)', borderTop: '1px solid #1e2740', borderBottom: '1px solid #1e2740', padding: '72px 24px', textAlign: 'center' }}>
+        <h2 style={{ fontSize: 'clamp(24px, 4vw, 42px)', fontWeight: 800, marginBottom: '16px', color: '#e8eaf0' }}>
+          Ready to take control of your health?
+        </h2>
+        <p style={{ color: '#9aa5c4', marginBottom: '36px', fontSize: '16px' }}>Join thousands already on LunaSol.</p>
+        <button style={{ background: 'linear-gradient(135deg, #7c9fff, #c084fc)', border: 'none', color: '#fff', padding: '16px 40px', borderRadius: '10px', fontSize: '17px', fontWeight: 600, cursor: 'pointer' }}>
+          Create free account
+        </button>
+      </section>
+
+      {/* Footer */}
+      <footer style={{ textAlign: 'center', padding: '32px', color: '#3b4f7a', fontSize: '13px' }}>
+        © {new Date().getFullYear()} LunaSol. All rights reserved.
+      </footer>
+
     </div>
   )
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -25,13 +25,13 @@ export default function Home() {
       {/* Hero */}
       <section style={{ textAlign: 'center', padding: '96px 24px 80px', borderBottom: '1px solid #e5e7eb' }}>
         <div style={{ display: 'inline-block', background: '#f3f4f6', border: '1px solid #e5e7eb', borderRadius: '999px', padding: '5px 14px', fontSize: '13px', color: '#6b7280', marginBottom: '28px', fontWeight: 500 }}>
-          Telehealth · AI-Assisted Care
+          Telehealth · Digital Care
         </div>
         <h1 style={{ fontSize: 'clamp(36px, 6vw, 64px)', fontWeight: 800, lineHeight: 1.1, margin: '0 auto 20px', maxWidth: '760px', color: '#111827', letterSpacing: '-1.5px' }}>
-          Healthcare, reimagined with AI
+          Better care, closer to you
         </h1>
         <p style={{ fontSize: '18px', color: '#6b7280', maxWidth: '500px', margin: '0 auto 44px', lineHeight: 1.7 }}>
-          Connect with your care team, get AI-powered insights, and manage your health — all in one place.
+          Connect with your care team, track your health, and manage appointments — all in one place.
         </p>
         <div style={{ display: 'flex', gap: '12px', justifyContent: 'center', flexWrap: 'wrap' }}>
           <button disabled style={{ display: 'flex', alignItems: 'center', gap: '8px', background: '#9ca3af', border: 'none', color: '#fff', padding: '13px 28px', borderRadius: '8px', fontSize: '15px', fontWeight: 600, cursor: 'not-allowed' }}>
@@ -50,7 +50,7 @@ export default function Home() {
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '24px' }}>
           {[
             { Icon: Video, title: 'Virtual Consultations', desc: 'Connect with licensed providers from home via secure video or chat.' },
-            { Icon: Bot, title: 'AI Health Assistant', desc: 'Get instant answers and triage guidance powered by our AI model.' },
+            { Icon: Bot, title: 'Health Assistant', desc: 'Get instant answers and triage guidance from our clinical support tool.' },
             { Icon: FolderOpen, title: 'Health Records', desc: 'All your records, prescriptions, and history in one secure place.' },
             { Icon: Bell, title: 'Smart Reminders', desc: 'Never miss a medication, appointment, or follow-up.' },
           ].map(({ Icon, title, desc }) => (

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -13,10 +13,10 @@ export default function Home() {
           <a href="#" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '15px' }}>Features</a>
           <a href="#" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '15px' }}>About</a>
           <a href="#" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '15px' }}>Contact</a>
-          <button style={{ background: 'transparent', border: '1px solid #d1d5db', color: '#374151', padding: '8px 20px', borderRadius: '8px', cursor: 'pointer', fontSize: '14px', fontWeight: 500 }}>
+          <button disabled style={{ background: 'transparent', border: '1px solid #d1d5db', color: '#9ca3af', padding: '8px 20px', borderRadius: '8px', cursor: 'not-allowed', fontSize: '14px', fontWeight: 500, opacity: 0.6 }}>
             Sign in
           </button>
-          <button style={{ background: '#111827', border: 'none', color: '#ffffff', padding: '8px 20px', borderRadius: '8px', cursor: 'pointer', fontSize: '14px', fontWeight: 500 }}>
+          <button disabled style={{ background: '#9ca3af', border: 'none', color: '#ffffff', padding: '8px 20px', borderRadius: '8px', cursor: 'not-allowed', fontSize: '14px', fontWeight: 500 }}>
             Get started
           </button>
         </div>
@@ -34,10 +34,10 @@ export default function Home() {
           Connect with your care team, get AI-powered insights, and manage your health — all in one place.
         </p>
         <div style={{ display: 'flex', gap: '12px', justifyContent: 'center', flexWrap: 'wrap' }}>
-          <button style={{ display: 'flex', alignItems: 'center', gap: '8px', background: '#111827', border: 'none', color: '#fff', padding: '13px 28px', borderRadius: '8px', fontSize: '15px', fontWeight: 600, cursor: 'pointer' }}>
+          <button disabled style={{ display: 'flex', alignItems: 'center', gap: '8px', background: '#9ca3af', border: 'none', color: '#fff', padding: '13px 28px', borderRadius: '8px', fontSize: '15px', fontWeight: 600, cursor: 'not-allowed' }}>
             Get started <ArrowRight size={16} />
           </button>
-          <button style={{ background: 'transparent', border: '1px solid #d1d5db', color: '#374151', padding: '13px 28px', borderRadius: '8px', fontSize: '15px', fontWeight: 500, cursor: 'pointer' }}>
+          <button disabled style={{ background: 'transparent', border: '1px solid #d1d5db', color: '#9ca3af', padding: '13px 28px', borderRadius: '8px', fontSize: '15px', fontWeight: 500, cursor: 'not-allowed', opacity: 0.6 }}>
             Learn more
           </button>
         </div>
@@ -71,7 +71,7 @@ export default function Home() {
           Ready to take control of your health?
         </h2>
         <p style={{ color: '#6b7280', marginBottom: '32px', fontSize: '16px' }}>Join thousands already on LunaSol.</p>
-        <button style={{ display: 'inline-flex', alignItems: 'center', gap: '8px', background: '#111827', border: 'none', color: '#fff', padding: '14px 32px', borderRadius: '8px', fontSize: '16px', fontWeight: 600, cursor: 'pointer' }}>
+        <button disabled style={{ display: 'inline-flex', alignItems: 'center', gap: '8px', background: '#9ca3af', border: 'none', color: '#fff', padding: '14px 32px', borderRadius: '8px', fontSize: '16px', fontWeight: 600, cursor: 'not-allowed' }}>
           Create free account <ArrowRight size={16} />
         </button>
       </section>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,71 +1,83 @@
+import { Video, Bot, FolderOpen, Bell, ArrowRight } from 'lucide-react'
+
 export default function Home() {
   return (
-    <div style={{ fontFamily: "'Segoe UI', system-ui, sans-serif", background: '#0a0f1e', minHeight: '100vh', color: '#e8eaf0' }}>
+    <div style={{ fontFamily: "'Segoe UI', system-ui, sans-serif", background: '#ffffff', minHeight: '100vh', color: '#111827' }}>
 
       {/* Nav */}
-      <nav style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '24px 48px', borderBottom: '1px solid #1e2740' }}>
-        <span style={{ fontSize: '22px', fontWeight: 700, background: 'linear-gradient(135deg, #7c9fff, #c084fc)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
+      <nav style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '20px 48px', borderBottom: '1px solid #e5e7eb' }}>
+        <span style={{ fontSize: '20px', fontWeight: 700, color: '#111827', letterSpacing: '-0.5px' }}>
           LunaSol
         </span>
-        <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
-          <a href="#" style={{ color: '#9aa5c4', textDecoration: 'none', fontSize: '15px' }}>Features</a>
-          <a href="#" style={{ color: '#9aa5c4', textDecoration: 'none', fontSize: '15px' }}>About</a>
-          <button style={{ background: 'transparent', border: '1px solid #3b4f7a', color: '#9aa5c4', padding: '8px 20px', borderRadius: '8px', cursor: 'pointer', fontSize: '14px' }}>
+        <div style={{ display: 'flex', gap: '32px', alignItems: 'center' }}>
+          <a href="#" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '15px' }}>Features</a>
+          <a href="#" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '15px' }}>About</a>
+          <a href="#" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '15px' }}>Contact</a>
+          <button style={{ background: 'transparent', border: '1px solid #d1d5db', color: '#374151', padding: '8px 20px', borderRadius: '8px', cursor: 'pointer', fontSize: '14px', fontWeight: 500 }}>
             Sign in
+          </button>
+          <button style={{ background: '#111827', border: 'none', color: '#ffffff', padding: '8px 20px', borderRadius: '8px', cursor: 'pointer', fontSize: '14px', fontWeight: 500 }}>
+            Get started
           </button>
         </div>
       </nav>
 
       {/* Hero */}
-      <section style={{ textAlign: 'center', padding: '100px 24px 80px' }}>
-        <div style={{ display: 'inline-block', background: '#111827', border: '1px solid #1e2740', borderRadius: '999px', padding: '6px 16px', fontSize: '13px', color: '#7c9fff', marginBottom: '28px' }}>
+      <section style={{ textAlign: 'center', padding: '96px 24px 80px', borderBottom: '1px solid #e5e7eb' }}>
+        <div style={{ display: 'inline-block', background: '#f3f4f6', border: '1px solid #e5e7eb', borderRadius: '999px', padding: '5px 14px', fontSize: '13px', color: '#6b7280', marginBottom: '28px', fontWeight: 500 }}>
           Telehealth · AI-Assisted Care
         </div>
-        <h1 style={{ fontSize: 'clamp(36px, 6vw, 72px)', fontWeight: 800, lineHeight: 1.1, margin: '0 auto 24px', maxWidth: '800px', background: 'linear-gradient(160deg, #ffffff 40%, #7c9fff)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>
+        <h1 style={{ fontSize: 'clamp(36px, 6vw, 64px)', fontWeight: 800, lineHeight: 1.1, margin: '0 auto 20px', maxWidth: '760px', color: '#111827', letterSpacing: '-1.5px' }}>
           Healthcare, reimagined with AI
         </h1>
-        <p style={{ fontSize: '18px', color: '#9aa5c4', maxWidth: '520px', margin: '0 auto 48px', lineHeight: 1.7 }}>
+        <p style={{ fontSize: '18px', color: '#6b7280', maxWidth: '500px', margin: '0 auto 44px', lineHeight: 1.7 }}>
           Connect with your care team, get AI-powered insights, and manage your health — all in one place.
         </p>
-        <div style={{ display: 'flex', gap: '16px', justifyContent: 'center', flexWrap: 'wrap' }}>
-          <button style={{ background: 'linear-gradient(135deg, #7c9fff, #c084fc)', border: 'none', color: '#fff', padding: '14px 32px', borderRadius: '10px', fontSize: '16px', fontWeight: 600, cursor: 'pointer' }}>
-            Get started
+        <div style={{ display: 'flex', gap: '12px', justifyContent: 'center', flexWrap: 'wrap' }}>
+          <button style={{ display: 'flex', alignItems: 'center', gap: '8px', background: '#111827', border: 'none', color: '#fff', padding: '13px 28px', borderRadius: '8px', fontSize: '15px', fontWeight: 600, cursor: 'pointer' }}>
+            Get started <ArrowRight size={16} />
           </button>
-          <button style={{ background: 'transparent', border: '1px solid #3b4f7a', color: '#9aa5c4', padding: '14px 32px', borderRadius: '10px', fontSize: '16px', cursor: 'pointer' }}>
+          <button style={{ background: 'transparent', border: '1px solid #d1d5db', color: '#374151', padding: '13px 28px', borderRadius: '8px', fontSize: '15px', fontWeight: 500, cursor: 'pointer' }}>
             Learn more
           </button>
         </div>
       </section>
 
-      {/* Feature cards */}
-      <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '24px', maxWidth: '1100px', margin: '0 auto', padding: '0 24px 100px' }}>
-        {[
-          { icon: '🩺', title: 'Virtual Consultations', desc: 'Connect with licensed providers from home via secure video or chat.' },
-          { icon: '🤖', title: 'AI Health Assistant', desc: 'Get instant answers and triage guidance powered by our AI model.' },
-          { icon: '📋', title: 'Health Records', desc: 'All your records, prescriptions, and history in one secure place.' },
-          { icon: '🔔', title: 'Smart Reminders', desc: 'Never miss a medication, appointment, or follow-up.' },
-        ].map(({ icon, title, desc }) => (
-          <div key={title} style={{ background: '#111827', border: '1px solid #1e2740', borderRadius: '16px', padding: '32px 28px' }}>
-            <div style={{ fontSize: '32px', marginBottom: '16px' }}>{icon}</div>
-            <h3 style={{ fontSize: '17px', fontWeight: 700, marginBottom: '10px', color: '#e8eaf0' }}>{title}</h3>
-            <p style={{ fontSize: '14px', color: '#6b7a99', lineHeight: 1.6, margin: 0 }}>{desc}</p>
-          </div>
-        ))}
+      {/* Features */}
+      <section style={{ maxWidth: '1100px', margin: '0 auto', padding: '80px 24px' }}>
+        <h2 style={{ textAlign: 'center', fontSize: '28px', fontWeight: 700, marginBottom: '8px', letterSpacing: '-0.5px' }}>Everything you need</h2>
+        <p style={{ textAlign: 'center', color: '#6b7280', marginBottom: '56px', fontSize: '16px' }}>Built for patients and providers alike.</p>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '24px' }}>
+          {[
+            { Icon: Video, title: 'Virtual Consultations', desc: 'Connect with licensed providers from home via secure video or chat.' },
+            { Icon: Bot, title: 'AI Health Assistant', desc: 'Get instant answers and triage guidance powered by our AI model.' },
+            { Icon: FolderOpen, title: 'Health Records', desc: 'All your records, prescriptions, and history in one secure place.' },
+            { Icon: Bell, title: 'Smart Reminders', desc: 'Never miss a medication, appointment, or follow-up.' },
+          ].map(({ Icon, title, desc }) => (
+            <div key={title} style={{ background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '28px 24px' }}>
+              <div style={{ display: 'inline-flex', padding: '10px', background: '#f3f4f6', borderRadius: '8px', marginBottom: '16px' }}>
+                <Icon size={20} color="#374151" />
+              </div>
+              <h3 style={{ fontSize: '16px', fontWeight: 600, marginBottom: '8px', color: '#111827' }}>{title}</h3>
+              <p style={{ fontSize: '14px', color: '#6b7280', lineHeight: 1.6, margin: 0 }}>{desc}</p>
+            </div>
+          ))}
+        </div>
       </section>
 
-      {/* CTA banner */}
-      <section style={{ background: 'linear-gradient(135deg, #0d1a3a, #1a0d3a)', borderTop: '1px solid #1e2740', borderBottom: '1px solid #1e2740', padding: '72px 24px', textAlign: 'center' }}>
-        <h2 style={{ fontSize: 'clamp(24px, 4vw, 42px)', fontWeight: 800, marginBottom: '16px', color: '#e8eaf0' }}>
+      {/* CTA */}
+      <section style={{ background: '#f9fafb', borderTop: '1px solid #e5e7eb', borderBottom: '1px solid #e5e7eb', padding: '72px 24px', textAlign: 'center' }}>
+        <h2 style={{ fontSize: 'clamp(24px, 4vw, 36px)', fontWeight: 700, marginBottom: '12px', letterSpacing: '-0.5px' }}>
           Ready to take control of your health?
         </h2>
-        <p style={{ color: '#9aa5c4', marginBottom: '36px', fontSize: '16px' }}>Join thousands already on LunaSol.</p>
-        <button style={{ background: 'linear-gradient(135deg, #7c9fff, #c084fc)', border: 'none', color: '#fff', padding: '16px 40px', borderRadius: '10px', fontSize: '17px', fontWeight: 600, cursor: 'pointer' }}>
-          Create free account
+        <p style={{ color: '#6b7280', marginBottom: '32px', fontSize: '16px' }}>Join thousands already on LunaSol.</p>
+        <button style={{ display: 'inline-flex', alignItems: 'center', gap: '8px', background: '#111827', border: 'none', color: '#fff', padding: '14px 32px', borderRadius: '8px', fontSize: '16px', fontWeight: 600, cursor: 'pointer' }}>
+          Create free account <ArrowRight size={16} />
         </button>
       </section>
 
       {/* Footer */}
-      <footer style={{ textAlign: 'center', padding: '32px', color: '#3b4f7a', fontSize: '13px' }}>
+      <footer style={{ textAlign: 'center', padding: '28px', color: '#9ca3af', fontSize: '13px', borderTop: '1px solid #e5e7eb' }}>
         © {new Date().getFullYear()} LunaSol. All rights reserved.
       </footer>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@lunasol/types':
         specifier: workspace:*
         version: link:../../packages/types
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@18.3.1)
       next:
         specifier: 14.2.29
         version: 14.2.29(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1819,6 +1822,11 @@ packages:
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -4282,6 +4290,10 @@ snapshots:
   lru-cache@11.5.0: {}
 
   lru.min@1.1.4: {}
+
+  lucide-react@1.16.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   magic-string@0.30.17:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds landing page with hero, feature cards, and CTA banner
- Light mode design using system colors, no gradients
- Lucide icons (Video, Bot, FolderOpen, Bell) for feature cards
- All CTA buttons disabled as placeholders

## Commits
- `chore(web)`: add lucide-react dependency
- `feat(web)`: redesign landing page to light mode with Lucide icons
- `chore(web)`: disable all CTA buttons as placeholders