### PR TITLE
feat(web): add healthcare cross favicon

### DIFF
--- a/apps/web/src/app/icon.svg
+++ b/apps/web/src/app/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#111827"/>
+  <rect x="14" y="7" width="4" height="18" rx="2" fill="white"/>
+  <rect x="7" y="14" width="18" height="4" rx="2" fill="white"/>
+</svg>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'LunaSol Telehealth',
-  description: 'Telehealth and AI assistant platform',
+  description: 'Telehealth and digital care platform',
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary
- Adds `icon.svg` to the Next.js app directory — a white medical cross on dark background, auto-picked up as the browser favicon
- Updates site description to remove "AI assistant platform"