### PR TITLE
feat: patient profile API and onboarding flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,8 @@ __pycache__/
 .venv/
 venv/
 
+# Uploaded files
+apps/api/uploads/
+
 # Local/private files — exclude hackathon brief but track planning docs
 planning

--- a/apps/api/Dockerfile.prod
+++ b/apps/api/Dockerfile.prod
@@ -38,5 +38,7 @@ COPY apps/api/prisma.config.ts ./prisma.config.ts
 
 RUN node_modules/.bin/prisma generate
 
+RUN mkdir -p /app/uploads/profile-pictures
+
 EXPOSE 3001
 CMD ["node", "dist/main"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,8 @@
     "@nestjs/platform-express": "^11.1.1",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.15.1",
     "pg": "^8.13.3",
     "prisma": "^7.8.0",
     "reflect-metadata": "^0.2.2",
@@ -29,6 +31,7 @@
   "devDependencies": {
     "@nestjs/cli": "^11.0.7",
     "@types/express": "^5.0.3",
+    "@types/multer": "^2.1.0",
     "@types/node": "^22.15.21",
     "@types/pg": "^8.11.11",
     "dotenv": "^16.4.7",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "@prisma/client": "^7.8.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
+    "multer": "^2.1.1",
     "pg": "^8.13.3",
     "prisma": "^7.8.0",
     "reflect-metadata": "^0.2.2",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common'
 import { PrismaModule } from './prisma/prisma.module'
 import { AuthModule } from './auth/auth.module'
+import { PatientsModule } from './patients/patients.module'
 
 @Module({
-  imports: [PrismaModule, AuthModule],
+  imports: [PrismaModule, AuthModule, PatientsModule],
 })
 export class AppModule {}

--- a/apps/api/src/auth/guards/role.guard.ts
+++ b/apps/api/src/auth/guards/role.guard.ts
@@ -22,7 +22,7 @@ export class RoleGuard implements CanActivate {
       throw new ForbiddenException('Access denied: user role not verified')
     }
 
-    const hasRole = requiredRoles.includes(user.role)
+    const hasRole = requiredRoles.some(r => r.toLowerCase() === user.role?.toLowerCase())
     if (!hasRole) {
       throw new ForbiddenException(`Access denied: required role is one of [${requiredRoles.join(', ')}]`)
     }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,9 +1,14 @@
 import { NestFactory } from '@nestjs/core'
+import { ValidationPipe } from '@nestjs/common'
+import { NestExpressApplication } from '@nestjs/platform-express'
+import { join } from 'path'
 import { AppModule } from './app.module'
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, { rawBody: true })
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, { rawBody: true })
   app.setGlobalPrefix('api')
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }))
+  app.useStaticAssets(join(process.cwd(), 'uploads'), { prefix: '/api/uploads' })
   await app.listen(3001)
   console.log('API is running on port 3001')
 }

--- a/apps/api/src/patients/dto/update-profile.dto.ts
+++ b/apps/api/src/patients/dto/update-profile.dto.ts
@@ -1,0 +1,33 @@
+import { IsString, IsOptional, IsNumber, IsDateString, Min } from 'class-validator'
+
+export class UpdateProfileDto {
+  @IsOptional()
+  @IsString()
+  name?: string
+
+  @IsOptional()
+  @IsDateString()
+  birthday?: string
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  weight?: number
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  height?: number
+
+  @IsOptional()
+  @IsString()
+  phone?: string
+
+  @IsOptional()
+  @IsString()
+  address?: string
+
+  @IsOptional()
+  @IsString()
+  medicalHistory?: string
+}

--- a/apps/api/src/patients/patients.controller.ts
+++ b/apps/api/src/patients/patients.controller.ts
@@ -30,7 +30,7 @@ const profilePictureStorage = diskStorage({
 })
 
 @Controller('patients')
-@Roles('PATIENT')
+@Roles('patient')
 export class PatientsController {
   constructor(private patientsService: PatientsService) {}
 

--- a/apps/api/src/patients/patients.controller.ts
+++ b/apps/api/src/patients/patients.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Post,
+  Body,
+  Req,
+  UseInterceptors,
+  UploadedFile,
+  BadRequestException,
+} from '@nestjs/common'
+import { FileInterceptor } from '@nestjs/platform-express'
+import { diskStorage } from 'multer'
+import { mkdirSync } from 'fs'
+import { extname, join } from 'path'
+import { Roles } from '../auth/decorators/roles.decorator'
+import { PatientsService } from './patients.service'
+import { UpdateProfileDto } from './dto/update-profile.dto'
+
+const uploadDir = join(process.cwd(), 'uploads', 'profile-pictures')
+mkdirSync(uploadDir, { recursive: true })
+
+const profilePictureStorage = diskStorage({
+  destination: uploadDir,
+  filename: (_req: any, file, cb) => {
+    const userId = _req.user?.id || 'unknown'
+    const ext = extname(file.originalname)
+    cb(null, `${userId}-${Date.now()}${ext}`)
+  },
+})
+
+@Controller('patients')
+@Roles('PATIENT')
+export class PatientsController {
+  constructor(private patientsService: PatientsService) {}
+
+  @Get('me')
+  async getProfile(@Req() req: any) {
+    return this.patientsService.getProfile(req.user.id)
+  }
+
+  @Patch('me')
+  async updateProfile(@Req() req: any, @Body() dto: UpdateProfileDto) {
+    return this.patientsService.updateProfile(req.user.id, dto)
+  }
+
+  @Post('me/picture')
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: profilePictureStorage,
+      limits: { fileSize: 5 * 1024 * 1024 },
+      fileFilter: (_req, file, cb) => {
+        if (!file.mimetype.startsWith('image/')) {
+          cb(new BadRequestException('Only image files are allowed'), false)
+          return
+        }
+        cb(null, true)
+      },
+    }),
+  )
+  async uploadPicture(@Req() req: any, @UploadedFile() file: Express.Multer.File) {
+    if (!file) {
+      throw new BadRequestException('No file uploaded')
+    }
+    return this.patientsService.updatePicture(req.user.id, file.filename)
+  }
+}

--- a/apps/api/src/patients/patients.module.ts
+++ b/apps/api/src/patients/patients.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common'
+import { PatientsController } from './patients.controller'
+import { PatientsService } from './patients.service'
+
+@Module({
+  controllers: [PatientsController],
+  providers: [PatientsService],
+})
+export class PatientsModule {}

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -1,9 +1,12 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
+import { createClerkClient } from '@clerk/backend'
 import { PrismaService } from '../prisma/prisma.service'
 import { UpdateProfileDto } from './dto/update-profile.dto'
 
 @Injectable()
 export class PatientsService {
+  private clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY })
+
   constructor(private prisma: PrismaService) {}
 
   async getProfile(clerkId: string) {
@@ -22,15 +25,42 @@ export class PatientsService {
     return { ...profile, profileComplete }
   }
 
-  async updateProfile(clerkId: string, dto: UpdateProfileDto) {
-    const user = await this.prisma.user.findUnique({
+  // Ensures a User + PatientProfile row exists, creating it if the webhook hasn't fired yet.
+  private async ensurePatientRecord(clerkId: string) {
+    let user = await this.prisma.user.findUnique({
       where: { clerkId },
       include: { patient: true },
     })
 
-    if (!user?.patient) {
-      throw new NotFoundException('Patient profile not found')
+    if (!user) {
+      const clerkUser = await this.clerk.users.getUser(clerkId)
+      const email = clerkUser.emailAddresses[0]?.emailAddress ?? ''
+      user = await this.prisma.user.create({
+        data: {
+          clerkId,
+          email,
+          role: 'PATIENT',
+          patient: {
+            create: { name: '', birthday: new Date('1990-01-01'), weight: 0, height: 0 },
+          },
+        },
+        include: { patient: true },
+      })
+    } else if (!user.patient) {
+      await this.prisma.patientProfile.create({
+        data: { userId: user.id, name: '', birthday: new Date('1990-01-01'), weight: 0, height: 0 },
+      })
+      user = await this.prisma.user.findUnique({
+        where: { clerkId },
+        include: { patient: true },
+      })
     }
+
+    return user!
+  }
+
+  async updateProfile(clerkId: string, dto: UpdateProfileDto) {
+    const user = await this.ensurePatientRecord(clerkId)
 
     const data: Record<string, any> = {}
     if (dto.name !== undefined) data.name = dto.name
@@ -42,7 +72,7 @@ export class PatientsService {
     if (dto.medicalHistory !== undefined) data.medicalHistory = dto.medicalHistory
 
     const updated = await this.prisma.patientProfile.update({
-      where: { id: user.patient.id },
+      where: { id: user.patient!.id },
       data,
     })
 
@@ -51,17 +81,10 @@ export class PatientsService {
   }
 
   async updatePicture(clerkId: string, filename: string) {
-    const user = await this.prisma.user.findUnique({
-      where: { clerkId },
-      include: { patient: true },
-    })
-
-    if (!user?.patient) {
-      throw new NotFoundException('Patient profile not found')
-    }
+    const user = await this.ensurePatientRecord(clerkId)
 
     const updated = await this.prisma.patientProfile.update({
-      where: { id: user.patient.id },
+      where: { id: user.patient!.id },
       data: { profilePictureUrl: `/api/uploads/profile-pictures/${filename}` },
     })
 

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, NotFoundException } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+import { UpdateProfileDto } from './dto/update-profile.dto'
+
+@Injectable()
+export class PatientsService {
+  constructor(private prisma: PrismaService) {}
+
+  async getProfile(clerkId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { clerkId },
+      include: { patient: true },
+    })
+
+    if (!user?.patient) {
+      throw new NotFoundException('Patient profile not found')
+    }
+
+    const profile = user.patient
+    const profileComplete = profile.weight > 0 && profile.height > 0
+
+    return { ...profile, profileComplete }
+  }
+
+  async updateProfile(clerkId: string, dto: UpdateProfileDto) {
+    const user = await this.prisma.user.findUnique({
+      where: { clerkId },
+      include: { patient: true },
+    })
+
+    if (!user?.patient) {
+      throw new NotFoundException('Patient profile not found')
+    }
+
+    const data: Record<string, any> = {}
+    if (dto.name !== undefined) data.name = dto.name
+    if (dto.birthday !== undefined) data.birthday = new Date(dto.birthday)
+    if (dto.weight !== undefined) data.weight = dto.weight
+    if (dto.height !== undefined) data.height = dto.height
+    if (dto.phone !== undefined) data.phone = dto.phone
+    if (dto.address !== undefined) data.address = dto.address
+    if (dto.medicalHistory !== undefined) data.medicalHistory = dto.medicalHistory
+
+    const updated = await this.prisma.patientProfile.update({
+      where: { id: user.patient.id },
+      data,
+    })
+
+    const profileComplete = updated.weight > 0 && updated.height > 0
+    return { ...updated, profileComplete }
+  }
+
+  async updatePicture(clerkId: string, filename: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { clerkId },
+      include: { patient: true },
+    })
+
+    if (!user?.patient) {
+      throw new NotFoundException('Patient profile not found')
+    }
+
+    const updated = await this.prisma.patientProfile.update({
+      where: { id: user.patient.id },
+      data: { profilePictureUrl: `/api/uploads/profile-pictures/${filename}` },
+    })
+
+    const profileComplete = updated.weight > 0 && updated.height > 0
+    return { ...updated, profileComplete }
+  }
+}

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -17,6 +17,8 @@ COPY packages/types ./packages/types
 COPY apps/web ./apps/web
 
 WORKDIR /app/apps/web
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 RUN pnpm build
 
 FROM node:22-alpine AS runner

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -27,6 +27,9 @@ export default async function DashboardRedirectPage() {
       if (!profile.profileComplete) {
         redirect('/dashboard/patient/onboarding')
       }
+    } else if (res.status === 404) {
+      // Webhook hasn't fired yet — user has no DB record, treat as incomplete
+      redirect('/dashboard/patient/onboarding')
     }
   } catch {
     // If API is unreachable, fall through to dashboard

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -2,7 +2,7 @@ import { auth, currentUser } from '@clerk/nextjs/server'
 import { redirect } from 'next/navigation'
 
 export default async function DashboardRedirectPage() {
-  const { userId } = await auth()
+  const { userId, getToken } = await auth()
   if (!userId) {
     redirect('/sign-in')
   }
@@ -12,7 +12,25 @@ export default async function DashboardRedirectPage() {
 
   if (role === 'doctor') {
     redirect('/dashboard/doctor')
-  } else {
-    redirect('/dashboard/patient')
   }
+
+  // Check if patient profile is complete before sending to dashboard
+  try {
+    const token = await getToken()
+    const apiBase = process.env.INTERNAL_API_URL || 'http://localhost:3001'
+    const res = await fetch(`${apiBase}/api/patients/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    })
+    if (res.ok) {
+      const profile = await res.json()
+      if (!profile.profileComplete) {
+        redirect('/dashboard/patient/onboarding')
+      }
+    }
+  } catch {
+    // If API is unreachable, fall through to dashboard
+  }
+
+  redirect('/dashboard/patient')
 }

--- a/apps/web/src/app/dashboard/patient/components/ProfileForm.tsx
+++ b/apps/web/src/app/dashboard/patient/components/ProfileForm.tsx
@@ -1,0 +1,343 @@
+'use client'
+
+import { useState, useRef, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@clerk/nextjs'
+import { Camera } from 'lucide-react'
+import { apiFetch } from '@/lib/api'
+
+interface ProfileData {
+  name: string
+  birthday: string
+  weight: number
+  height: number
+  phone: string
+  address: string
+  medicalHistory: string
+  profilePictureUrl: string | null
+}
+
+const defaultProfile: ProfileData = {
+  name: '',
+  birthday: '',
+  weight: 0,
+  height: 0,
+  phone: '',
+  address: '',
+  medicalHistory: '',
+  profilePictureUrl: null,
+}
+
+function formatDate(iso: string) {
+  if (!iso) return ''
+  return iso.slice(0, 10)
+}
+
+export default function ProfileForm({ mode }: { mode: 'onboarding' | 'edit' }) {
+  const router = useRouter()
+  const { getToken } = useAuth()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const [profile, setProfile] = useState<ProfileData>(defaultProfile)
+  const [pictureFile, setPictureFile] = useState<File | null>(null)
+  const [picturePreview, setPicturePreview] = useState<string | null>(null)
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [loading, setLoading] = useState(false)
+  const [fetching, setFetching] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const token = await getToken()
+        const data = await apiFetch('/patients/me', { token: token || undefined })
+        setProfile({
+          name: data.name || '',
+          birthday: formatDate(data.birthday),
+          weight: data.weight || 0,
+          height: data.height || 0,
+          phone: data.phone || '',
+          address: data.address || '',
+          medicalHistory: data.medicalHistory || '',
+          profilePictureUrl: data.profilePictureUrl || null,
+        })
+      } catch {
+        // Profile doesn't exist yet, keep defaults
+      } finally {
+        setFetching(false)
+      }
+    }
+    load()
+  }, [getToken])
+
+  function validate(): boolean {
+    const e: Record<string, string> = {}
+    if (!profile.name.trim()) e.name = 'Name is required'
+    if (!profile.birthday) e.birthday = 'Birthday is required'
+    if (!profile.weight || profile.weight <= 0) e.weight = 'Enter a valid weight'
+    if (!profile.height || profile.height <= 0) e.height = 'Enter a valid height'
+    setErrors(e)
+    return Object.keys(e).length === 0
+  }
+
+  function handlePictureChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setPictureFile(file)
+    setPicturePreview(URL.createObjectURL(file))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+
+    setLoading(true)
+    try {
+      const token = await getToken()
+      const tokenStr = token || undefined
+
+      await apiFetch('/patients/me', {
+        token: tokenStr,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: profile.name,
+          birthday: profile.birthday,
+          weight: profile.weight,
+          height: profile.height,
+          phone: profile.phone || undefined,
+          address: profile.address || undefined,
+          medicalHistory: profile.medicalHistory || undefined,
+        }),
+      })
+
+      if (pictureFile) {
+        const form = new FormData()
+        form.append('file', pictureFile)
+        await apiFetch('/patients/me/picture', {
+          token: tokenStr,
+          method: 'POST',
+          body: form,
+        })
+      }
+
+      router.push('/dashboard/patient')
+    } catch (err) {
+      setErrors({ form: err instanceof Error ? err.message : 'Failed to save profile' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (fetching) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '60vh' }}>
+        <p style={{ color: '#6b7280', fontSize: '16px' }}>Loading...</p>
+      </div>
+    )
+  }
+
+  const pictureUrl = picturePreview || profile.profilePictureUrl
+  const isOnboarding = mode === 'onboarding'
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '10px 14px',
+    fontSize: '14px',
+    border: '1px solid #d1d5db',
+    borderRadius: '8px',
+    outline: 'none',
+    fontFamily: "'Segoe UI', system-ui, sans-serif",
+    boxSizing: 'border-box',
+  }
+
+  const labelStyle: React.CSSProperties = {
+    display: 'block',
+    fontSize: '14px',
+    fontWeight: 600,
+    color: '#111827',
+    marginBottom: '6px',
+  }
+
+  const errorStyle: React.CSSProperties = {
+    color: '#dc2626',
+    fontSize: '13px',
+    marginTop: '4px',
+  }
+
+  return (
+    <div style={{ maxWidth: '640px', margin: '0 auto', padding: '40px 24px' }}>
+      <div style={{ marginBottom: '32px' }}>
+        <h1 style={{ fontSize: '24px', fontWeight: 700, color: '#111827', margin: '0 0 8px 0', letterSpacing: '-0.5px' }}>
+          {isOnboarding ? 'Complete your profile' : 'Edit profile'}
+        </h1>
+        <p style={{ fontSize: '15px', color: '#6b7280', margin: 0, lineHeight: 1.5 }}>
+          {isOnboarding
+            ? 'Fill in your details so your care team has the information they need.'
+            : 'Update your personal and medical information.'}
+        </p>
+      </div>
+
+      {errors.form && (
+        <div style={{ background: '#fef2f2', border: '1px solid #fecaca', borderRadius: '8px', padding: '12px 16px', marginBottom: '24px', color: '#dc2626', fontSize: '14px' }}>
+          {errors.form}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit}>
+        {/* Profile picture */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '20px', marginBottom: '32px' }}>
+          <div
+            onClick={() => fileInputRef.current?.click()}
+            style={{
+              width: '80px',
+              height: '80px',
+              borderRadius: '50%',
+              background: pictureUrl ? `url(${pictureUrl}) center/cover` : '#f3f4f6',
+              border: '2px dashed #d1d5db',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+              flexShrink: 0,
+              overflow: 'hidden',
+            }}
+          >
+            {!pictureUrl && <Camera size={24} color="#9ca3af" />}
+          </div>
+          <div>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              style={{ background: 'none', border: '1px solid #d1d5db', borderRadius: '8px', padding: '8px 16px', fontSize: '13px', fontWeight: 600, color: '#374151', cursor: 'pointer' }}
+            >
+              {pictureUrl ? 'Change photo' : 'Upload photo'}
+            </button>
+            <p style={{ fontSize: '12px', color: '#9ca3af', marginTop: '4px', marginBottom: 0 }}>JPG, PNG up to 5 MB</p>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={handlePictureChange}
+            style={{ display: 'none' }}
+          />
+        </div>
+
+        {/* Name */}
+        <div style={{ marginBottom: '20px' }}>
+          <label style={labelStyle}>Full name *</label>
+          <input
+            style={{ ...inputStyle, borderColor: errors.name ? '#dc2626' : '#d1d5db' }}
+            value={profile.name}
+            onChange={(e) => setProfile((p) => ({ ...p, name: e.target.value }))}
+            placeholder="Jane Doe"
+          />
+          {errors.name && <p style={errorStyle}>{errors.name}</p>}
+        </div>
+
+        {/* Birthday */}
+        <div style={{ marginBottom: '20px' }}>
+          <label style={labelStyle}>Date of birth *</label>
+          <input
+            type="date"
+            style={{ ...inputStyle, borderColor: errors.birthday ? '#dc2626' : '#d1d5db' }}
+            value={profile.birthday}
+            onChange={(e) => setProfile((p) => ({ ...p, birthday: e.target.value }))}
+          />
+          {errors.birthday && <p style={errorStyle}>{errors.birthday}</p>}
+        </div>
+
+        {/* Weight & Height */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px', marginBottom: '20px' }}>
+          <div>
+            <label style={labelStyle}>Weight (kg) *</label>
+            <input
+              type="number"
+              step="0.1"
+              style={{ ...inputStyle, borderColor: errors.weight ? '#dc2626' : '#d1d5db' }}
+              value={profile.weight || ''}
+              onChange={(e) => setProfile((p) => ({ ...p, weight: parseFloat(e.target.value) || 0 }))}
+              placeholder="70"
+            />
+            {errors.weight && <p style={errorStyle}>{errors.weight}</p>}
+          </div>
+          <div>
+            <label style={labelStyle}>Height (cm) *</label>
+            <input
+              type="number"
+              step="0.1"
+              style={{ ...inputStyle, borderColor: errors.height ? '#dc2626' : '#d1d5db' }}
+              value={profile.height || ''}
+              onChange={(e) => setProfile((p) => ({ ...p, height: parseFloat(e.target.value) || 0 }))}
+              placeholder="170"
+            />
+            {errors.height && <p style={errorStyle}>{errors.height}</p>}
+          </div>
+        </div>
+
+        {/* Phone */}
+        <div style={{ marginBottom: '20px' }}>
+          <label style={labelStyle}>Phone</label>
+          <input
+            type="tel"
+            style={inputStyle}
+            value={profile.phone}
+            onChange={(e) => setProfile((p) => ({ ...p, phone: e.target.value }))}
+            placeholder="+1 (555) 123-4567"
+          />
+        </div>
+
+        {/* Address */}
+        <div style={{ marginBottom: '20px' }}>
+          <label style={labelStyle}>Address</label>
+          <textarea
+            style={{ ...inputStyle, minHeight: '72px', resize: 'vertical' }}
+            value={profile.address}
+            onChange={(e) => setProfile((p) => ({ ...p, address: e.target.value }))}
+            placeholder="123 Main St, City, State"
+          />
+        </div>
+
+        {/* Medical history */}
+        <div style={{ marginBottom: '32px' }}>
+          <label style={labelStyle}>Medical history</label>
+          <textarea
+            style={{ ...inputStyle, minHeight: '96px', resize: 'vertical' }}
+            value={profile.medicalHistory}
+            onChange={(e) => setProfile((p) => ({ ...p, medicalHistory: e.target.value }))}
+            placeholder="Allergies, chronic conditions, past surgeries..."
+          />
+        </div>
+
+        {/* Submit */}
+        <div style={{ display: 'flex', gap: '12px', justifyContent: 'flex-end' }}>
+          {!isOnboarding && (
+            <button
+              type="button"
+              onClick={() => router.push('/dashboard/patient')}
+              style={{ background: '#ffffff', border: '1px solid #d1d5db', color: '#374151', padding: '12px 24px', borderRadius: '8px', fontSize: '14px', fontWeight: 600, cursor: 'pointer' }}
+            >
+              Cancel
+            </button>
+          )}
+          <button
+            type="submit"
+            disabled={loading}
+            style={{
+              background: loading ? '#9ca3af' : '#111827',
+              border: 'none',
+              color: '#ffffff',
+              padding: '12px 32px',
+              borderRadius: '8px',
+              fontSize: '14px',
+              fontWeight: 600,
+              cursor: loading ? 'not-allowed' : 'pointer',
+            }}
+          >
+            {loading ? 'Saving...' : isOnboarding ? 'Complete profile' : 'Save changes'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/apps/web/src/app/dashboard/patient/components/ProfileForm.tsx
+++ b/apps/web/src/app/dashboard/patient/components/ProfileForm.tsx
@@ -71,10 +71,35 @@ export default function ProfileForm({ mode }: { mode: 'onboarding' | 'edit' }) {
 
   function validate(): boolean {
     const e: Record<string, string> = {}
+
     if (!profile.name.trim()) e.name = 'Name is required'
-    if (!profile.birthday) e.birthday = 'Birthday is required'
+
+    if (!profile.birthday) {
+      e.birthday = 'Date of birth is required'
+    } else {
+      const d = new Date(profile.birthday)
+      const year = d.getFullYear()
+      const now = new Date()
+      if (isNaN(d.getTime())) {
+        e.birthday = 'Enter a valid date'
+      } else if (year < 1900 || year > now.getFullYear()) {
+        e.birthday = `Year must be between 1900 and ${now.getFullYear()}`
+      } else if (d > now) {
+        e.birthday = 'Date of birth cannot be in the future'
+      }
+    }
+
     if (!profile.weight || profile.weight <= 0) e.weight = 'Enter a valid weight'
     if (!profile.height || profile.height <= 0) e.height = 'Enter a valid height'
+
+    if (profile.phone) {
+      // E.164-ish: + followed by country code (1–3 digits) and subscriber number, total 7–15 digits
+      const phoneRegex = /^\+[1-9]\d{6,14}$/
+      if (!phoneRegex.test(profile.phone.replace(/[\s\-().]/g, ''))) {
+        e.phone = 'Include country code (e.g. +1 555 123 4567). Must be 7–15 digits total.'
+      }
+    }
+
     setErrors(e)
     return Object.keys(e).length === 0
   }
@@ -240,6 +265,8 @@ export default function ProfileForm({ mode }: { mode: 'onboarding' | 'edit' }) {
           <label style={labelStyle}>Date of birth *</label>
           <input
             type="date"
+            min="1900-01-01"
+            max={new Date().toISOString().slice(0, 10)}
             style={{ ...inputStyle, borderColor: errors.birthday ? '#dc2626' : '#d1d5db' }}
             value={profile.birthday}
             onChange={(e) => setProfile((p) => ({ ...p, birthday: e.target.value }))}
@@ -280,11 +307,15 @@ export default function ProfileForm({ mode }: { mode: 'onboarding' | 'edit' }) {
           <label style={labelStyle}>Phone</label>
           <input
             type="tel"
-            style={inputStyle}
+            style={{ ...inputStyle, borderColor: errors.phone ? '#dc2626' : '#d1d5db' }}
             value={profile.phone}
             onChange={(e) => setProfile((p) => ({ ...p, phone: e.target.value }))}
-            placeholder="+1 (555) 123-4567"
+            placeholder="+1 555 123 4567"
           />
+          {errors.phone
+            ? <p style={errorStyle}>{errors.phone}</p>
+            : <p style={{ fontSize: '12px', color: '#9ca3af', marginTop: '4px', marginBottom: 0 }}>Include country code, e.g. +1 555 123 4567</p>
+          }
         </div>
 
         {/* Address */}

--- a/apps/web/src/app/dashboard/patient/components/ProfileForm.tsx
+++ b/apps/web/src/app/dashboard/patient/components/ProfileForm.tsx
@@ -147,7 +147,8 @@ export default function ProfileForm({ mode }: { mode: 'onboarding' | 'edit' }) {
 
       router.push('/dashboard/patient')
     } catch (err) {
-      setErrors({ form: err instanceof Error ? err.message : 'Failed to save profile' })
+      console.error('Profile save failed:', err)
+      setErrors({ form: 'Something went wrong. Please try again.' })
     } finally {
       setLoading(false)
     }

--- a/apps/web/src/app/dashboard/patient/onboarding/page.tsx
+++ b/apps/web/src/app/dashboard/patient/onboarding/page.tsx
@@ -1,0 +1,12 @@
+import ProfileForm from '../components/ProfileForm'
+
+export default function OnboardingPage() {
+  return (
+    <div style={{ fontFamily: "'Segoe UI', system-ui, sans-serif", background: '#f9fafb', minHeight: '100vh', color: '#111827' }}>
+      <nav style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '16px 40px', background: '#ffffff', borderBottom: '1px solid #e5e7eb' }}>
+        <span style={{ fontSize: '18px', fontWeight: 700, color: '#111827', letterSpacing: '-0.5px' }}>LunaSol</span>
+      </nav>
+      <ProfileForm mode="onboarding" />
+    </div>
+  )
+}

--- a/apps/web/src/app/dashboard/patient/page.tsx
+++ b/apps/web/src/app/dashboard/patient/page.tsx
@@ -22,6 +22,7 @@ export default async function PatientDashboard() {
           <a href="#" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '14px', fontWeight: 500 }}>Find Doctors</a>
           <a href="#" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '14px', fontWeight: 500 }}>Appointments</a>
           <a href="#" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '14px', fontWeight: 500 }}>Records</a>
+          <a href="/dashboard/patient/profile" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '14px', fontWeight: 500 }}>Profile</a>
           <UserButton />
         </div>
       </nav>

--- a/apps/web/src/app/dashboard/patient/profile/page.tsx
+++ b/apps/web/src/app/dashboard/patient/profile/page.tsx
@@ -1,0 +1,17 @@
+import { UserButton } from '@clerk/nextjs'
+import ProfileForm from '../components/ProfileForm'
+
+export default function ProfileEditPage() {
+  return (
+    <div style={{ fontFamily: "'Segoe UI', system-ui, sans-serif", background: '#f9fafb', minHeight: '100vh', color: '#111827' }}>
+      <nav style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '16px 40px', background: '#ffffff', borderBottom: '1px solid #e5e7eb', position: 'sticky', top: 0, zIndex: 10 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <a href="/dashboard/patient" style={{ fontSize: '18px', fontWeight: 700, color: '#111827', letterSpacing: '-0.5px', textDecoration: 'none' }}>LunaSol</a>
+          <span style={{ background: '#e0f2fe', color: '#0369a1', fontSize: '12px', fontWeight: 600, padding: '2px 8px', borderRadius: '4px' }}>Patient Portal</span>
+        </div>
+        <UserButton />
+      </nav>
+      <ProfileForm mode="edit" />
+    </div>
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,21 @@
+export async function apiFetch(
+  path: string,
+  options: RequestInit & { token?: string } = {},
+) {
+  const { token, headers, ...rest } = options
+
+  const res = await fetch(`/api${path}`, {
+    ...rest,
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...headers,
+    },
+  })
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.message || `API error ${res.status}`)
+  }
+
+  return res.json()
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,16 +1,10 @@
 import { clerkMiddleware } from '@clerk/nextjs/server'
 
-export default clerkMiddleware({
-  frontendApiProxy: {
-    enabled: true,
-    path: '/__clerk',
-  },
-})
+export default clerkMiddleware()
 
 export const config = {
   matcher: [
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     '/(api|trpc)(.*)',
-    '/__clerk/(.*)',
   ],
 }

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,10 +1,17 @@
 import { clerkMiddleware } from '@clerk/nextjs/server'
 
-export default clerkMiddleware()
+// frontendApiProxy only works with production Clerk instances (pk_live_*).
+// Dev instances use Clerk's standard dev-browser redirect mechanism instead.
+const isProduction = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.startsWith('pk_live_')
+
+export default clerkMiddleware(
+  isProduction ? { frontendApiProxy: { enabled: true, path: '/__clerk' } } : {},
+)
 
 export const config = {
   matcher: [
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     '/(api|trpc)(.*)',
+    '/__clerk/(.*)',
   ],
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,11 +5,13 @@ services:
     build:
       context: .
       dockerfile: apps/web/Dockerfile.prod
+      args:
+        - NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
     container_name: lunasol-prod-web
     restart: unless-stopped
     environment:
-      - NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
       - CLERK_SECRET_KEY=${CLERK_SECRET_KEY}
+      - INTERNAL_API_URL=http://api:3001
     depends_on:
       api:
         condition: service_healthy
@@ -27,6 +29,8 @@ services:
       - CLERK_SECRET_KEY=${CLERK_SECRET_KEY}
       - CLERK_WEBHOOK_SECRET=${CLERK_WEBHOOK_SECRET}
       - NODE_ENV=production
+    volumes:
+      - uploads_data:/app/uploads
     depends_on:
       db:
         condition: service_healthy
@@ -109,6 +113,7 @@ services:
 
 volumes:
   postgres_data:
+  uploads_data:
 
 networks:
   lunasol:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
       - CLERK_SECRET_KEY=${CLERK_SECRET_KEY}
+      - INTERNAL_API_URL=http://api:3001
     depends_on:
       - api
     networks:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       class-validator:
         specifier: ^0.15.1
         version: 0.15.1
+      multer:
+        specifier: ^2.1.1
+        version: 2.1.1
       pg:
         specifier: ^8.13.3
         version: 8.21.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,19 +52,25 @@ importers:
         version: link:../../packages/types
       '@nestjs/common':
         specifier: ^11.1.1
-        version: 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^11.1.1
-        version: 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        version: 11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-express':
         specifier: ^11.1.1
-        version: 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)
+        version: 11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)
       '@prisma/adapter-pg':
         specifier: ^7.8.0
         version: 7.8.0
       '@prisma/client':
         specifier: ^7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)
+      class-transformer:
+        specifier: ^0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: ^0.15.1
+        version: 0.15.1
       pg:
         specifier: ^8.13.3
         version: 8.21.0
@@ -87,6 +93,9 @@ importers:
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.6
+      '@types/multer':
+        specifier: ^2.1.0
+        version: 2.1.0
       '@types/node':
         specifier: ^22.15.21
         version: 22.19.19
@@ -935,6 +944,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/multer@2.1.0':
+    resolution: {integrity: sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==}
+
   '@types/node@22.19.19':
     resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
@@ -963,6 +975,9 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/validator@13.15.10':
+    resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
 
   '@typescript-eslint/eslint-plugin@8.60.0':
     resolution: {integrity: sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==}
@@ -1257,6 +1272,12 @@ packages:
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
+
+  class-transformer@0.5.1:
+    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
+
+  class-validator@0.15.1:
+    resolution: {integrity: sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -1839,6 +1860,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libphonenumber-js@1.13.3:
+    resolution: {integrity: sha512-xMkdAMqcyG7iN2WZZmGIfWbYxW4orRkny+0/AXIbwL0xll2zkDX0Vzo/BXFa6+7mh2UvJl9MbcTtHk0YXkFtBA==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -2596,6 +2620,10 @@ packages:
       typescript:
         optional: true
 
+  validator@13.15.35:
+    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
+    engines: {node: '>= 0.10'}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -3072,7 +3100,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       file-type: 21.3.4
       iterare: 1.2.1
@@ -3081,12 +3109,15 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
       uid: 2.0.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.15.1
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/core@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/core@11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nuxt/opencollective': 0.4.1
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
@@ -3096,12 +3127,12 @@ snapshots:
       tslib: 2.8.1
       uid: 2.0.2
     optionalDependencies:
-      '@nestjs/platform-express': 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)
+      '@nestjs/platform-express': 11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)
 
-  '@nestjs/platform-express@11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)':
+  '@nestjs/platform-express@11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.24)':
     dependencies:
-      '@nestjs/common': 11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.24(@nestjs/common@11.1.24(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.24(@nestjs/common@11.1.24(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.24)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cors: 2.8.6
       express: 5.2.1
       multer: 2.1.1
@@ -3401,6 +3432,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/multer@2.1.0':
+    dependencies:
+      '@types/express': 5.0.6
+
   '@types/node@22.19.19':
     dependencies:
       undici-types: 6.21.0
@@ -3434,6 +3469,8 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 22.19.19
+
+  '@types/validator@13.15.10': {}
 
   '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -3788,6 +3825,14 @@ snapshots:
       readdirp: 5.0.0
 
   chrome-trace-event@1.0.4: {}
+
+  class-transformer@0.5.1: {}
+
+  class-validator@0.15.1:
+    dependencies:
+      '@types/validator': 13.15.10
+      libphonenumber-js: 1.13.3
+      validator: 13.15.35
 
   cli-cursor@3.1.0:
     dependencies:
@@ -4375,6 +4420,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libphonenumber-js@1.13.3: {}
 
   lines-and-columns@1.2.4: {}
 
@@ -5059,6 +5106,8 @@ snapshots:
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
+
+  validator@13.15.35: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary

- **Backend:** `GET/PATCH /api/patients/me` + `POST /api/patients/me/picture` with class-validator DTOs, multer disk storage, and static asset serving
- **Frontend:** Dashboard auto-redirects to `/dashboard/patient/onboarding` when profile is incomplete (weight/height = 0) or missing (webhook race condition handled via Clerk API upsert)
- **Profile form:** Shared `ProfileForm` component for onboarding and edit flows with validated date range (1900–today), E.164 phone format, and required fields
- **Bug fix:** Role guard comparison was case-sensitive (`'PATIENT'` vs `'patient'` from JWT) — normalized to case-insensitive; all patient endpoints now correctly enforce the role

## Test plan

- [ ] Sign up as a new patient → redirected to `/dashboard/patient/onboarding`
- [ ] Fill required fields (name, birthday, weight, height) → redirected to patient dashboard
- [ ] Visit `/dashboard/patient/profile` → form pre-filled, changes save correctly
- [ ] Upload a profile picture → preview shown, saved on submit
- [ ] Enter invalid date (year < 1900 or future) → validation error shown
- [ ] Enter phone without country code → validation error shown
- [ ] Patient JWT on `GET /api/patients/me` → 200
- [ ] Doctor JWT on `GET /api/patients/me` → 403