### PR TITLE
feat: patient track — doctor discovery, booking, and medical records (closes #16 #17 #21 #22 #23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,3 @@ coverage/
 
 # Local/private files — exclude hackathon brief but track planning docs
 planning
-
-# Claude Code
-CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ coverage/
 
 # Local/private files — exclude hackathon brief but track planning docs
 planning
+
+# Claude Code
+CLAUDE.md

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,8 +3,9 @@ import { PrismaModule } from './prisma/prisma.module'
 import { AuthModule } from './auth/auth.module'
 import { PatientsModule } from './patients/patients.module'
 import { DoctorsModule } from './doctors/doctors.module'
+import { AppointmentsModule } from './appointments/appointments.module'
 
 @Module({
-  imports: [PrismaModule, AuthModule, PatientsModule, DoctorsModule],
+  imports: [PrismaModule, AuthModule, PatientsModule, DoctorsModule, AppointmentsModule],
 })
 export class AppModule {}

--- a/apps/api/src/appointments/appointments.controller.ts
+++ b/apps/api/src/appointments/appointments.controller.ts
@@ -1,0 +1,52 @@
+import { Controller, Post, Get, Patch, Param, Body, Req } from '@nestjs/common'
+import { Roles } from '../auth/decorators/roles.decorator'
+import { AppointmentsService } from './appointments.service'
+import { BookAppointmentDto } from './dto/book-appointment.dto'
+import { RescheduleAppointmentDto } from './dto/reschedule-appointment.dto'
+
+@Controller('appointments')
+export class AppointmentsController {
+  constructor(private appointmentsService: AppointmentsService) {}
+
+  @Roles('patient')
+  @Post()
+  book(@Req() req: any, @Body() dto: BookAppointmentDto) {
+    return this.appointmentsService.book(req.user.id, dto)
+  }
+
+  @Roles('patient', 'doctor')
+  @Get('mine')
+  listMine(@Req() req: any) {
+    return this.appointmentsService.listMine(req.user.id, req.user.role)
+  }
+
+  @Roles('patient', 'doctor')
+  @Get(':id')
+  getOne(@Req() req: any, @Param('id') id: string) {
+    return this.appointmentsService.getOne(req.user.id, id, req.user.role)
+  }
+
+  @Roles('patient')
+  @Patch(':id/cancel')
+  cancel(@Req() req: any, @Param('id') id: string) {
+    return this.appointmentsService.cancel(req.user.id, id)
+  }
+
+  @Roles('patient')
+  @Patch(':id/reschedule')
+  reschedule(@Req() req: any, @Param('id') id: string, @Body() dto: RescheduleAppointmentDto) {
+    return this.appointmentsService.reschedule(req.user.id, id, dto)
+  }
+
+  @Roles('doctor')
+  @Patch(':id/confirm')
+  confirm(@Req() req: any, @Param('id') id: string) {
+    return this.appointmentsService.confirm(req.user.id, id)
+  }
+
+  @Roles('doctor')
+  @Patch(':id/complete')
+  complete(@Req() req: any, @Param('id') id: string) {
+    return this.appointmentsService.complete(req.user.id, id)
+  }
+}

--- a/apps/api/src/appointments/appointments.module.ts
+++ b/apps/api/src/appointments/appointments.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common'
+import { AppointmentsController } from './appointments.controller'
+import { AppointmentsService } from './appointments.service'
+
+@Module({
+  controllers: [AppointmentsController],
+  providers: [AppointmentsService],
+})
+export class AppointmentsModule {}

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -34,46 +34,51 @@ export class AppointmentsService {
   }
 
   private async createNotification(recipientId: string, type: string, message: string) {
+    // TODO: emit real-time event via NotificationsService once #9 (Socket.io gateway) lands
     await this.prisma.notification.create({
       data: { recipientId, type, message },
     })
   }
 
   async book(clerkId: string, dto: BookAppointmentDto) {
-    const { user: patientUser, patient } = await this.getPatientProfile(clerkId)
+    const { patient } = await this.getPatientProfile(clerkId)
 
-    const slot = await this.prisma.availabilitySlot.findUnique({
-      where: { id: dto.slotId },
-      include: { appointment: true, doctor: { include: { user: true } } },
-    })
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const slot = await tx.availabilitySlot.findUnique({
+          where: { id: dto.slotId },
+          include: { appointment: true, doctor: { include: { user: true } } },
+        })
 
-    if (!slot) throw new NotFoundException('Slot not found')
-    if (slot.isBlocked) throw new ConflictException('Slot is blocked')
-    if (slot.appointment) throw new ConflictException('Slot is already booked')
-    if (slot.startTime <= new Date()) throw new BadRequestException('Slot is in the past')
+        if (!slot) throw new NotFoundException('Slot not found')
+        if (slot.isBlocked) throw new ConflictException('Slot is blocked')
+        if (slot.appointment) throw new ConflictException('Slot is already booked')
+        if (slot.startTime <= new Date()) throw new BadRequestException('Slot is in the past')
 
-    const appointment = await this.prisma.appointment.create({
-      data: {
-        patientId: patient.id,
-        doctorId: slot.doctorId,
-        slotId: slot.id,
-        status: AppointmentStatus.PENDING,
-      },
-      include: {
-        slot: true,
-        doctor: true,
-        patient: true,
-      },
-    })
+        const appointment = await tx.appointment.create({
+          data: {
+            patientId: patient.id,
+            doctorId: slot.doctorId,
+            slotId: slot.id,
+            status: AppointmentStatus.PENDING,
+          },
+          include: { slot: true, doctor: true, patient: true },
+        })
 
-    // Notify doctor of new appointment request
-    await this.createNotification(
-      slot.doctor.user.id,
-      'APPOINTMENT_REQUEST',
-      `New appointment request from ${patient.name} on ${slot.startTime.toLocaleDateString()}`,
-    )
+        await tx.notification.create({
+          data: {
+            recipientId: slot.doctor.user.id,
+            type: 'APPOINTMENT_REQUEST',
+            message: `New appointment request from ${patient.name} on ${slot.startTime.toLocaleDateString()}`,
+          },
+        })
 
-    return appointment
+        return appointment
+      })
+    } catch (e: any) {
+      if (e?.code === 'P2002') throw new ConflictException('Slot is already booked')
+      throw e
+    }
   }
 
   async listMine(clerkId: string, role: string) {
@@ -89,7 +94,7 @@ export class AppointmentsService {
     const { patient } = await this.getPatientProfile(clerkId)
     return this.prisma.appointment.findMany({
       where: { patientId: patient.id },
-      include: { slot: true, doctor: true },
+      include: { slot: true, doctor: true, record: { include: { prescriptions: true } } },
       orderBy: { slot: { startTime: 'asc' } },
     })
   }
@@ -140,30 +145,39 @@ export class AppointmentsService {
       throw new ConflictException(`Cannot reschedule a ${appointment.status.toLowerCase()} appointment`)
     }
 
-    const newSlot = await this.prisma.availabilitySlot.findUnique({
-      where: { id: dto.newSlotId },
-      include: { appointment: true },
-    })
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const newSlot = await tx.availabilitySlot.findUnique({
+          where: { id: dto.newSlotId },
+          include: { appointment: true },
+        })
 
-    if (!newSlot) throw new NotFoundException('New slot not found')
-    if (newSlot.doctorId !== appointment.doctorId) throw new BadRequestException('Slot belongs to a different doctor')
-    if (newSlot.isBlocked) throw new ConflictException('New slot is blocked')
-    if (newSlot.appointment) throw new ConflictException('New slot is already booked')
-    if (newSlot.startTime <= new Date()) throw new BadRequestException('New slot is in the past')
+        if (!newSlot) throw new NotFoundException('New slot not found')
+        if (newSlot.doctorId !== appointment.doctorId) throw new BadRequestException('Slot belongs to a different doctor')
+        if (newSlot.isBlocked) throw new ConflictException('New slot is blocked')
+        if (newSlot.appointment) throw new ConflictException('New slot is already booked')
+        if (newSlot.startTime <= new Date()) throw new BadRequestException('New slot is in the past')
 
-    const updated = await this.prisma.appointment.update({
-      where: { id },
-      data: { slotId: dto.newSlotId },
-      include: { slot: true, doctor: true },
-    })
+        const updated = await tx.appointment.update({
+          where: { id },
+          data: { slotId: dto.newSlotId },
+          include: { slot: true, doctor: true },
+        })
 
-    await this.createNotification(
-      appointment.doctor.user.id,
-      'APPOINTMENT_RESCHEDULED',
-      `${patient.name} rescheduled their appointment to ${newSlot.startTime.toLocaleDateString()}`,
-    )
+        await tx.notification.create({
+          data: {
+            recipientId: appointment.doctor.user.id,
+            type: 'APPOINTMENT_RESCHEDULED',
+            message: `${patient.name} rescheduled their appointment to ${newSlot.startTime.toLocaleDateString()}`,
+          },
+        })
 
-    return updated
+        return updated
+      })
+    } catch (e: any) {
+      if (e?.code === 'P2002') throw new ConflictException('New slot is already booked')
+      throw e
+    }
   }
 
   async confirm(clerkId: string, id: string) {

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -1,0 +1,243 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common'
+import { randomUUID } from 'node:crypto'
+import { PrismaService } from '../prisma/prisma.service'
+import { BookAppointmentDto } from './dto/book-appointment.dto'
+import { RescheduleAppointmentDto } from './dto/reschedule-appointment.dto'
+import { AppointmentStatus } from '@prisma/client'
+
+@Injectable()
+export class AppointmentsService {
+  constructor(private prisma: PrismaService) {}
+
+  private async getPatientProfile(clerkId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { clerkId },
+      include: { patient: true },
+    })
+    if (!user?.patient) throw new NotFoundException('Patient profile not found')
+    return { user, patient: user.patient }
+  }
+
+  private async getDoctorProfile(clerkId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { clerkId },
+      include: { doctor: true },
+    })
+    if (!user?.doctor) throw new NotFoundException('Doctor profile not found')
+    return { user, doctor: user.doctor }
+  }
+
+  private async createNotification(recipientId: string, type: string, message: string) {
+    await this.prisma.notification.create({
+      data: { recipientId, type, message },
+    })
+  }
+
+  async book(clerkId: string, dto: BookAppointmentDto) {
+    const { user: patientUser, patient } = await this.getPatientProfile(clerkId)
+
+    const slot = await this.prisma.availabilitySlot.findUnique({
+      where: { id: dto.slotId },
+      include: { appointment: true, doctor: { include: { user: true } } },
+    })
+
+    if (!slot) throw new NotFoundException('Slot not found')
+    if (slot.isBlocked) throw new ConflictException('Slot is blocked')
+    if (slot.appointment) throw new ConflictException('Slot is already booked')
+    if (slot.startTime <= new Date()) throw new BadRequestException('Slot is in the past')
+
+    const appointment = await this.prisma.appointment.create({
+      data: {
+        patientId: patient.id,
+        doctorId: slot.doctorId,
+        slotId: slot.id,
+        status: AppointmentStatus.PENDING,
+      },
+      include: {
+        slot: true,
+        doctor: true,
+        patient: true,
+      },
+    })
+
+    // Notify doctor of new appointment request
+    await this.createNotification(
+      slot.doctor.user.id,
+      'APPOINTMENT_REQUEST',
+      `New appointment request from ${patient.name} on ${slot.startTime.toLocaleDateString()}`,
+    )
+
+    return appointment
+  }
+
+  async listMine(clerkId: string, role: string) {
+    if (role === 'doctor') {
+      const { doctor } = await this.getDoctorProfile(clerkId)
+      return this.prisma.appointment.findMany({
+        where: { doctorId: doctor.id },
+        include: { slot: true, patient: true },
+        orderBy: { slot: { startTime: 'asc' } },
+      })
+    }
+
+    const { patient } = await this.getPatientProfile(clerkId)
+    return this.prisma.appointment.findMany({
+      where: { patientId: patient.id },
+      include: { slot: true, doctor: true },
+      orderBy: { slot: { startTime: 'asc' } },
+    })
+  }
+
+  async cancel(clerkId: string, id: string) {
+    const { patient } = await this.getPatientProfile(clerkId)
+
+    const appointment = await this.prisma.appointment.findUnique({
+      where: { id },
+      include: { slot: true, doctor: { include: { user: true } }, patient: true },
+    })
+
+    if (!appointment) throw new NotFoundException('Appointment not found')
+    if (appointment.patientId !== patient.id) throw new ForbiddenException('Not your appointment')
+    if (
+      appointment.status === AppointmentStatus.CANCELLED ||
+      appointment.status === AppointmentStatus.COMPLETED
+    ) {
+      throw new ConflictException(`Cannot cancel a ${appointment.status.toLowerCase()} appointment`)
+    }
+
+    const updated = await this.prisma.appointment.update({
+      where: { id },
+      data: { status: AppointmentStatus.CANCELLED },
+      include: { slot: true, doctor: true },
+    })
+
+    await this.createNotification(
+      appointment.doctor.user.id,
+      'APPOINTMENT_CANCELLED',
+      `${patient.name} cancelled their appointment on ${appointment.slot.startTime.toLocaleDateString()}`,
+    )
+
+    return updated
+  }
+
+  async reschedule(clerkId: string, id: string, dto: RescheduleAppointmentDto) {
+    const { patient } = await this.getPatientProfile(clerkId)
+
+    const appointment = await this.prisma.appointment.findUnique({
+      where: { id },
+      include: { slot: true, doctor: { include: { user: true } }, patient: true },
+    })
+
+    if (!appointment) throw new NotFoundException('Appointment not found')
+    if (appointment.patientId !== patient.id) throw new ForbiddenException('Not your appointment')
+    if (appointment.status === AppointmentStatus.CANCELLED || appointment.status === AppointmentStatus.COMPLETED) {
+      throw new ConflictException(`Cannot reschedule a ${appointment.status.toLowerCase()} appointment`)
+    }
+
+    const newSlot = await this.prisma.availabilitySlot.findUnique({
+      where: { id: dto.newSlotId },
+      include: { appointment: true },
+    })
+
+    if (!newSlot) throw new NotFoundException('New slot not found')
+    if (newSlot.doctorId !== appointment.doctorId) throw new BadRequestException('Slot belongs to a different doctor')
+    if (newSlot.isBlocked) throw new ConflictException('New slot is blocked')
+    if (newSlot.appointment) throw new ConflictException('New slot is already booked')
+    if (newSlot.startTime <= new Date()) throw new BadRequestException('New slot is in the past')
+
+    const updated = await this.prisma.appointment.update({
+      where: { id },
+      data: { slotId: dto.newSlotId },
+      include: { slot: true, doctor: true },
+    })
+
+    await this.createNotification(
+      appointment.doctor.user.id,
+      'APPOINTMENT_RESCHEDULED',
+      `${patient.name} rescheduled their appointment to ${newSlot.startTime.toLocaleDateString()}`,
+    )
+
+    return updated
+  }
+
+  async confirm(clerkId: string, id: string) {
+    const { doctor } = await this.getDoctorProfile(clerkId)
+
+    const appointment = await this.prisma.appointment.findUnique({
+      where: { id },
+      include: { slot: true, patient: { include: { user: true } } },
+    })
+
+    if (!appointment) throw new NotFoundException('Appointment not found')
+    if (appointment.doctorId !== doctor.id) throw new ForbiddenException('Not your appointment')
+    if (appointment.status !== AppointmentStatus.PENDING) {
+      throw new ConflictException('Only pending appointments can be confirmed')
+    }
+
+    const jitsiRoom = `lunasol-${randomUUID().replace(/-/g, '').slice(0, 12)}`
+
+    const updated = await this.prisma.appointment.update({
+      where: { id },
+      data: { status: AppointmentStatus.CONFIRMED, jitsiRoom },
+      include: { slot: true, doctor: true },
+    })
+
+    await this.createNotification(
+      appointment.patient.user.id,
+      'APPOINTMENT_CONFIRMED',
+      `Your appointment on ${appointment.slot.startTime.toLocaleDateString()} has been confirmed. Join the session when it's time.`,
+    )
+
+    return updated
+  }
+
+  async complete(clerkId: string, id: string) {
+    const { doctor } = await this.getDoctorProfile(clerkId)
+
+    const appointment = await this.prisma.appointment.findUnique({
+      where: { id },
+    })
+
+    if (!appointment) throw new NotFoundException('Appointment not found')
+    if (appointment.doctorId !== doctor.id) throw new ForbiddenException('Not your appointment')
+    if (appointment.status !== AppointmentStatus.CONFIRMED) {
+      throw new ConflictException('Only confirmed appointments can be marked complete')
+    }
+
+    return this.prisma.appointment.update({
+      where: { id },
+      data: { status: AppointmentStatus.COMPLETED },
+      include: { slot: true, doctor: true },
+    })
+  }
+
+  async getOne(clerkId: string, id: string, role: string) {
+    const appointment = await this.prisma.appointment.findUnique({
+      where: { id },
+      include: {
+        slot: true,
+        doctor: true,
+        patient: true,
+        record: { include: { prescriptions: true } },
+      },
+    })
+
+    if (!appointment) throw new NotFoundException('Appointment not found')
+
+    if (role === 'doctor') {
+      const { doctor } = await this.getDoctorProfile(clerkId)
+      if (appointment.doctorId !== doctor.id) throw new ForbiddenException('Not your appointment')
+    } else {
+      const { patient } = await this.getPatientProfile(clerkId)
+      if (appointment.patientId !== patient.id) throw new ForbiddenException('Not your appointment')
+    }
+
+    return appointment
+  }
+}

--- a/apps/api/src/appointments/dto/book-appointment.dto.ts
+++ b/apps/api/src/appointments/dto/book-appointment.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator'
+
+export class BookAppointmentDto {
+  @IsString()
+  @IsNotEmpty()
+  slotId: string
+}

--- a/apps/api/src/appointments/dto/reschedule-appointment.dto.ts
+++ b/apps/api/src/appointments/dto/reschedule-appointment.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator'
+
+export class RescheduleAppointmentDto {
+  @IsString()
+  @IsNotEmpty()
+  newSlotId: string
+}

--- a/apps/api/src/doctors/doctors.controller.ts
+++ b/apps/api/src/doctors/doctors.controller.ts
@@ -6,6 +6,7 @@ import {
   Body,
   Req,
   Param,
+  Query,
   UseInterceptors,
   UploadedFile,
   BadRequestException,
@@ -41,8 +42,16 @@ export class DoctorsController implements OnModuleInit {
 
   @Public()
   @Get()
-  async listDoctors() {
-    return this.doctorsService.listDoctors()
+  async listDoctors(
+    @Query('specialization') specialization?: string,
+    @Query('search') search?: string,
+    @Query('available') available?: string,
+  ) {
+    return this.doctorsService.listDoctors({
+      specialization,
+      search,
+      available: available === 'true',
+    })
   }
 
   @Roles('doctor')
@@ -83,5 +92,11 @@ export class DoctorsController implements OnModuleInit {
   @Get(':id')
   async getDoctorById(@Param('id') id: string) {
     return this.doctorsService.getDoctorById(id)
+  }
+
+  @Public()
+  @Get(':id/availability')
+  async getDoctorAvailability(@Param('id') id: string) {
+    return this.doctorsService.getDoctorAvailability(id)
   }
 }

--- a/apps/api/src/doctors/doctors.service.ts
+++ b/apps/api/src/doctors/doctors.service.ts
@@ -25,9 +25,31 @@ export class DoctorsService {
     return { ...profile, profileComplete }
   }
 
-  async listDoctors() {
-    const doctors = await this.prisma.doctorProfile.findMany({
-      take: 50,
+  async listDoctors(filters: { specialization?: string; search?: string; available?: boolean } = {}) {
+    const now = new Date()
+    const conditions: any[] = []
+
+    if (filters.specialization) {
+      conditions.push({ specialization: { contains: filters.specialization, mode: 'insensitive' } })
+    }
+
+    if (filters.search) {
+      conditions.push({
+        OR: [
+          { name: { contains: filters.search, mode: 'insensitive' } },
+          { specialization: { contains: filters.search, mode: 'insensitive' } },
+        ],
+      })
+    }
+
+    if (filters.available) {
+      conditions.push({
+        slots: { some: { isBlocked: false, appointment: null, startTime: { gte: now } } },
+      })
+    }
+
+    return this.prisma.doctorProfile.findMany({
+      where: conditions.length > 0 ? { AND: conditions } : {},
       select: {
         id: true,
         name: true,
@@ -37,7 +59,6 @@ export class DoctorsService {
         contactDetails: true,
       },
     })
-    return doctors
   }
 
   async getDoctorById(id: string) {
@@ -58,6 +79,25 @@ export class DoctorsService {
     }
 
     return doctor
+  }
+
+  async getDoctorAvailability(id: string) {
+    const doctor = await this.prisma.doctorProfile.findUnique({ where: { id } })
+    if (!doctor) throw new NotFoundException('Doctor not found')
+
+    const now = new Date()
+    const cutoff = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000)
+
+    return this.prisma.availabilitySlot.findMany({
+      where: {
+        doctorId: id,
+        isBlocked: false,
+        appointment: null,
+        startTime: { gte: now, lte: cutoff },
+      },
+      select: { id: true, startTime: true, endTime: true },
+      orderBy: { startTime: 'asc' },
+    })
   }
 
   private async ensureDoctorRecord(clerkId: string) {

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -46,6 +46,9 @@ export class PatientsService {
         },
         include: { patient: true },
       })
+      await this.clerk.users.updateUserMetadata(clerkId, {
+        publicMetadata: { role: 'patient' },
+      })
     } else if (!user.patient) {
       await this.prisma.patientProfile.create({
         data: { userId: user.id, name: '', birthday: new Date('1990-01-01'), weight: 0, height: 0 },

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -13,47 +13,46 @@ export default async function DashboardRedirectPage() {
   const token = await getToken()
   const apiBase = process.env.INTERNAL_API_URL || 'http://localhost:3001'
 
+  console.log('[dashboard] userId:', userId, 'role:', role, 'hasToken:', !!token)
+
   if (role === 'doctor') {
-    if (token) {
-      try {
-        const res = await fetch(`${apiBase}/api/doctors/me`, {
-          headers: { Authorization: `Bearer ${token}` },
-          cache: 'no-store',
-        })
-        if (res.ok) {
-          const profile = await res.json()
-          if (!profile.profileComplete) redirect('/dashboard/doctor/onboarding')
-        } else if (res.status === 404) {
-          redirect('/dashboard/doctor/onboarding')
-        }
-      } catch (e) {
-        if ((e as any)?.digest?.startsWith('NEXT_REDIRECT')) throw e
-        // If API is unreachable, fall through to dashboard
+    try {
+      const res = await fetch(`${apiBase}/api/doctors/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+        cache: 'no-store',
+      })
+      console.log('[dashboard] GET /doctors/me status:', res.status)
+      if (res.ok) {
+        const profile = await res.json()
+        if (!profile.profileComplete) redirect('/dashboard/doctor/onboarding')
+      } else if (res.status === 404 || res.status === 401) {
+        redirect('/dashboard/doctor/onboarding')
       }
+    } catch (e) {
+      if ((e as any)?.digest?.startsWith('NEXT_REDIRECT')) throw e
+      console.error('[dashboard] doctors/me fetch error:', e)
     }
     redirect('/dashboard/doctor')
   }
 
   // Check if patient profile is complete before sending to dashboard
-  if (token) {
-    try {
-      const res = await fetch(`${apiBase}/api/patients/me`, {
-        headers: { Authorization: `Bearer ${token}` },
-        cache: 'no-store',
-      })
-      if (res.ok) {
-        const profile = await res.json()
-        if (!profile.profileComplete) {
-          redirect('/dashboard/patient/onboarding')
-        }
-      } else if (res.status === 404) {
-        // Webhook hasn't fired yet — user has no DB record, treat as incomplete
+  try {
+    const res = await fetch(`${apiBase}/api/patients/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    })
+    console.log('[dashboard] GET /patients/me status:', res.status)
+    if (res.ok) {
+      const profile = await res.json()
+      if (!profile.profileComplete) {
         redirect('/dashboard/patient/onboarding')
       }
-    } catch (e) {
-      if ((e as any)?.digest?.startsWith('NEXT_REDIRECT')) throw e
-      // If API is unreachable, fall through to dashboard
+    } else if (res.status === 404 || res.status === 401) {
+      redirect('/dashboard/patient/onboarding')
     }
+  } catch (e) {
+    if ((e as any)?.digest?.startsWith('NEXT_REDIRECT')) throw e
+    console.error('[dashboard] patients/me fetch error:', e)
   }
 
   redirect('/dashboard/patient')

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -25,7 +25,7 @@ export default async function DashboardRedirectPage() {
       if (res.ok) {
         const profile = await res.json()
         if (!profile.profileComplete) redirect('/dashboard/doctor/onboarding')
-      } else if (res.status === 404 || res.status === 401) {
+      } else if (res.status === 404 || res.status === 401 || res.status === 403) {
         redirect('/dashboard/doctor/onboarding')
       }
     } catch (e) {
@@ -47,7 +47,7 @@ export default async function DashboardRedirectPage() {
       if (!profile.profileComplete) {
         redirect('/dashboard/patient/onboarding')
       }
-    } else if (res.status === 404 || res.status === 401) {
+    } else if (res.status === 404 || res.status === 401 || res.status === 403) {
       redirect('/dashboard/patient/onboarding')
     }
   } catch (e) {

--- a/apps/web/src/app/dashboard/patient/appointments/page.tsx
+++ b/apps/web/src/app/dashboard/patient/appointments/page.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@clerk/nextjs'
+import { Calendar, Clock, Video } from 'lucide-react'
+import { apiFetch } from '@/lib/api'
+
+interface Appointment {
+  id: string
+  status: 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'COMPLETED'
+  jitsiRoom: string | null
+  doctor: { id: string; name: string; specialization: string; profilePictureUrl: string | null }
+  slot: { startTime: string; endTime: string }
+}
+
+const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
+  PENDING: { bg: '#fef9c3', text: '#854d0e' },
+  CONFIRMED: { bg: '#f0fdf4', text: '#166534' },
+  CANCELLED: { bg: '#fef2f2', text: '#991b1b' },
+  COMPLETED: { bg: '#f3f4f6', text: '#374151' },
+}
+
+export default function AppointmentsPage() {
+  const router = useRouter()
+  const { getToken } = useAuth()
+  const [appointments, setAppointments] = useState<Appointment[]>([])
+  const [loading, setLoading] = useState(true)
+  const [cancelling, setCancelling] = useState<string | null>(null)
+
+  async function load() {
+    try {
+      const token = await getToken()
+      const data = await apiFetch('/appointments/mine', { token: token || undefined })
+      setAppointments(data)
+    } catch {
+      // fall through
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { load() }, [])
+
+  async function handleCancel(id: string) {
+    if (!confirm('Cancel this appointment?')) return
+    setCancelling(id)
+    try {
+      const token = await getToken()
+      await apiFetch(`/appointments/${id}/cancel`, { token: token || undefined, method: 'PATCH' })
+      await load()
+    } catch (err: any) {
+      alert(err.message || 'Failed to cancel appointment.')
+    } finally {
+      setCancelling(null)
+    }
+  }
+
+  const upcoming = appointments.filter((a) => a.status === 'PENDING' || a.status === 'CONFIRMED')
+  const past = appointments.filter((a) => a.status === 'CANCELLED' || a.status === 'COMPLETED')
+
+  return (
+    <div style={{ fontFamily: "'Segoe UI', system-ui, sans-serif", background: '#f9fafb', minHeight: '100vh' }}>
+      <nav style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '16px 40px', background: '#ffffff', borderBottom: '1px solid #e5e7eb', position: 'sticky', top: 0, zIndex: 10 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <a href="/dashboard/patient" style={{ fontSize: '18px', fontWeight: 700, color: '#111827', textDecoration: 'none' }}>LunaSol</a>
+          <span style={{ color: '#d1d5db' }}>/</span>
+          <span style={{ fontSize: '14px', color: '#6b7280', fontWeight: 500 }}>Appointments</span>
+        </div>
+        <a href="/doctors" style={{ padding: '8px 16px', background: '#111827', borderRadius: '8px', fontSize: '13px', fontWeight: 600, color: '#ffffff', textDecoration: 'none' }}>
+          Book new
+        </a>
+      </nav>
+
+      <main style={{ maxWidth: '800px', margin: '0 auto', padding: '40px 24px' }}>
+        {loading ? (
+          <p style={{ color: '#9ca3af', textAlign: 'center', padding: '60px' }}>Loading appointments...</p>
+        ) : appointments.length === 0 ? (
+          <div style={{ textAlign: 'center', padding: '80px 0' }}>
+            <Calendar size={48} color="#d1d5db" style={{ margin: '0 auto 16px' }} />
+            <h2 style={{ fontSize: '18px', fontWeight: 600, color: '#111827', marginBottom: '8px' }}>No appointments yet</h2>
+            <p style={{ color: '#6b7280', marginBottom: '24px' }}>Browse our doctors and book your first consultation.</p>
+            <a href="/doctors" style={{ padding: '12px 24px', background: '#111827', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#ffffff', textDecoration: 'none' }}>
+              Find a doctor
+            </a>
+          </div>
+        ) : (
+          <>
+            {upcoming.length > 0 && (
+              <section style={{ marginBottom: '40px' }}>
+                <h2 style={{ fontSize: '18px', fontWeight: 700, color: '#111827', marginBottom: '16px' }}>Upcoming</h2>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                  {upcoming.map((appt) => <AppointmentCard key={appt.id} appt={appt} onCancel={handleCancel} cancelling={cancelling} onClick={() => router.push(`/dashboard/patient/appointments/${appt.id}`)} />)}
+                </div>
+              </section>
+            )}
+            {past.length > 0 && (
+              <section>
+                <h2 style={{ fontSize: '18px', fontWeight: 700, color: '#111827', marginBottom: '16px' }}>Past</h2>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                  {past.map((appt) => <AppointmentCard key={appt.id} appt={appt} onCancel={handleCancel} cancelling={cancelling} onClick={() => router.push(`/dashboard/patient/appointments/${appt.id}`)} />)}
+                </div>
+              </section>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  )
+}
+
+function AppointmentCard({ appt, onCancel, cancelling, onClick }: {
+  appt: Appointment
+  onCancel: (id: string) => void
+  cancelling: string | null
+  onClick: () => void
+}) {
+  const statusStyle = STATUS_COLORS[appt.status]
+  const date = new Date(appt.slot.startTime)
+  const canCancel = appt.status === 'PENDING' || appt.status === 'CONFIRMED'
+
+  return (
+    <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '20px 24px', cursor: 'pointer' }} onClick={onClick}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '12px' }}>
+        <div>
+          <h3 style={{ fontSize: '16px', fontWeight: 700, margin: '0 0 4px', color: '#111827' }}>{appt.doctor.name}</h3>
+          <p style={{ fontSize: '13px', color: '#6b7280', margin: 0 }}>{appt.doctor.specialization}</p>
+        </div>
+        <span style={{ fontSize: '11px', fontWeight: 700, padding: '3px 10px', borderRadius: '12px', background: statusStyle.bg, color: statusStyle.text, textTransform: 'uppercase', letterSpacing: '0.05em', whiteSpace: 'nowrap' }}>
+          {appt.status}
+        </span>
+      </div>
+
+      <div style={{ display: 'flex', gap: '20px', marginBottom: canCancel || appt.status === 'CONFIRMED' ? '16px' : '0' }}>
+        <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+          <Calendar size={14} /> {date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+        </span>
+        <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+          <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
+        </span>
+      </div>
+
+      {(canCancel || appt.status === 'CONFIRMED') && (
+        <div style={{ display: 'flex', gap: '8px' }} onClick={(e) => e.stopPropagation()}>
+          {appt.status === 'CONFIRMED' && appt.jitsiRoom && (
+            <a
+              href={`/meet/${appt.jitsiRoom}`}
+              style={{ display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 16px', background: '#059669', border: 'none', borderRadius: '8px', fontSize: '13px', fontWeight: 600, color: '#ffffff', textDecoration: 'none' }}
+            >
+              <Video size={14} /> Join session
+            </a>
+          )}
+          {canCancel && (
+            <button
+              onClick={() => onCancel(appt.id)}
+              disabled={cancelling === appt.id}
+              style={{ padding: '8px 16px', background: 'none', border: '1px solid #fca5a5', borderRadius: '8px', fontSize: '13px', fontWeight: 600, color: '#dc2626', cursor: 'pointer' }}
+            >
+              {cancelling === appt.id ? 'Cancelling...' : 'Cancel'}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/dashboard/patient/components/ProfileForm.tsx
+++ b/apps/web/src/app/dashboard/patient/components/ProfileForm.tsx
@@ -46,6 +46,12 @@ export default function ProfileForm({ mode }: { mode: 'onboarding' | 'edit' }) {
   const [fetching, setFetching] = useState(true)
 
   useEffect(() => {
+    return () => {
+      if (picturePreview) URL.revokeObjectURL(picturePreview)
+    }
+  }, [picturePreview])
+
+  useEffect(() => {
     async function load() {
       try {
         const token = await getToken()
@@ -107,6 +113,7 @@ export default function ProfileForm({ mode }: { mode: 'onboarding' | 'edit' }) {
   function handlePictureChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
+    if (picturePreview) URL.revokeObjectURL(picturePreview)
     setPictureFile(file)
     setPicturePreview(URL.createObjectURL(file))
   }

--- a/apps/web/src/app/dashboard/patient/page.tsx
+++ b/apps/web/src/app/dashboard/patient/page.tsx
@@ -19,9 +19,9 @@ export default async function PatientDashboard() {
           </span>
         </div>
         <div style={{ display: 'flex', gap: '24px', alignItems: 'center' }}>
-          <a href="#" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '14px', fontWeight: 500 }}>Find Doctors</a>
-          <a href="#" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '14px', fontWeight: 500 }}>Appointments</a>
-          <a href="#" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '14px', fontWeight: 500 }}>Records</a>
+          <a href="/doctors" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '14px', fontWeight: 500 }}>Find Doctors</a>
+          <a href="/dashboard/patient/appointments" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '14px', fontWeight: 500 }}>Appointments</a>
+          <a href="/dashboard/patient/records" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '14px', fontWeight: 500 }}>Records</a>
           <a href="/dashboard/patient/profile" style={{ color: '#6b7280', textDecoration: 'none', fontSize: '14px', fontWeight: 500 }}>Profile</a>
           <UserButton />
         </div>
@@ -42,11 +42,11 @@ export default async function PatientDashboard() {
         {/* Quick Stats / Actions */}
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '24px', marginBottom: '40px' }}>
           {[
-            { Icon: Video, title: 'Virtual Consultations', desc: 'Join or schedule a video call with a practitioner.', count: 'No active calls' },
-            { Icon: Calendar, title: 'Appointments', desc: 'View, reschedule, or book a doctor appointment.', count: '0 upcoming' },
-            { Icon: FolderOpen, title: 'Medical Records', desc: 'Securely access prescriptions and test results.', count: 'Updated recently' },
-          ].map(({ Icon, title, desc, count }) => (
-            <div key={title} style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '24px', boxShadow: '0 1px 3px rgba(0, 0, 0, 0.02)' }}>
+            { Icon: Video, title: 'Virtual Consultations', href: '/dashboard/patient/appointments', desc: 'Join or schedule a video call with a practitioner.', count: 'No active calls' },
+            { Icon: Calendar, title: 'Appointments', href: '/dashboard/patient/appointments', desc: 'View, reschedule, or book a doctor appointment.', count: '0 upcoming' },
+            { Icon: FolderOpen, title: 'Medical Records', href: '/dashboard/patient/records', desc: 'Securely access prescriptions and test results.', count: 'Updated recently' },
+          ].map(({ Icon, title, href, desc, count }) => (
+            <a key={title} href={href} style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '24px', boxShadow: '0 1px 3px rgba(0, 0, 0, 0.02)', textDecoration: 'none', display: 'block' }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '16px' }}>
                 <div style={{ display: 'inline-flex', padding: '8px', background: '#f3f4f6', borderRadius: '8px' }}>
                   <Icon size={20} color="#111827" />
@@ -57,7 +57,7 @@ export default async function PatientDashboard() {
               </div>
               <h3 style={{ fontSize: '16px', fontWeight: 600, marginBottom: '8px', color: '#111827' }}>{title}</h3>
               <p style={{ fontSize: '14px', color: '#6b7280', lineHeight: 1.5, margin: 0 }}>{desc}</p>
-            </div>
+            </a>
           ))}
         </div>
 
@@ -72,9 +72,9 @@ export default async function PatientDashboard() {
               Use our AI-powered clinical assistant to triage symptoms and receive curated advice.
             </p>
           </div>
-          <button style={{ background: '#111827', border: 'none', color: '#ffffff', padding: '12px 24px', borderRadius: '8px', fontSize: '14px', fontWeight: 600, cursor: 'pointer' }}>
-            Start Triage
-          </button>
+          <a href="/doctors" style={{ background: '#111827', border: 'none', color: '#ffffff', padding: '12px 24px', borderRadius: '8px', fontSize: '14px', fontWeight: 600, cursor: 'pointer', textDecoration: 'none' }}>
+            Find a Doctor
+          </a>
         </div>
       </main>
     </div>

--- a/apps/web/src/app/dashboard/patient/records/page.tsx
+++ b/apps/web/src/app/dashboard/patient/records/page.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useAuth } from '@clerk/nextjs'
+import { FolderOpen, ChevronDown, ChevronUp } from 'lucide-react'
+import { apiFetch } from '@/lib/api'
+
+interface Prescription {
+  id: string
+  medicationName: string
+  dosage: string
+  frequency: string
+  duration: string
+  notes: string | null
+}
+
+interface ConsultationRecord {
+  id: string
+  notes: string | null
+  prescriptions: Prescription[]
+}
+
+interface Appointment {
+  id: string
+  status: string
+  slot: { startTime: string }
+  doctor: { name: string; specialization: string }
+  record: ConsultationRecord | null
+}
+
+export default function RecordsPage() {
+  const { getToken } = useAuth()
+  const [appointments, setAppointments] = useState<Appointment[]>([])
+  const [loading, setLoading] = useState(true)
+  const [expanded, setExpanded] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const token = await getToken()
+        const data: Appointment[] = await apiFetch('/appointments/mine', { token: token || undefined })
+        setAppointments(data.filter((a) => a.status === 'COMPLETED'))
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [getToken])
+
+  return (
+    <div style={{ fontFamily: "'Segoe UI', system-ui, sans-serif", background: '#f9fafb', minHeight: '100vh' }}>
+      <nav style={{ display: 'flex', alignItems: 'center', gap: '12px', padding: '16px 40px', background: '#ffffff', borderBottom: '1px solid #e5e7eb', position: 'sticky', top: 0, zIndex: 10 }}>
+        <a href="/dashboard/patient" style={{ fontSize: '18px', fontWeight: 700, color: '#111827', textDecoration: 'none' }}>LunaSol</a>
+        <span style={{ color: '#d1d5db' }}>/</span>
+        <span style={{ fontSize: '14px', color: '#6b7280', fontWeight: 500 }}>Medical Records</span>
+      </nav>
+
+      <main style={{ maxWidth: '800px', margin: '0 auto', padding: '40px 24px' }}>
+        <div style={{ marginBottom: '32px' }}>
+          <h1 style={{ fontSize: '24px', fontWeight: 700, color: '#111827', margin: '0 0 8px', letterSpacing: '-0.5px' }}>Medical Records</h1>
+          <p style={{ fontSize: '15px', color: '#6b7280', margin: 0 }}>Your past consultations, notes, and prescriptions.</p>
+        </div>
+
+        {loading ? (
+          <p style={{ color: '#9ca3af', textAlign: 'center', padding: '60px' }}>Loading records...</p>
+        ) : appointments.length === 0 ? (
+          <div style={{ textAlign: 'center', padding: '80px 0' }}>
+            <FolderOpen size={48} color="#d1d5db" style={{ margin: '0 auto 16px' }} />
+            <h2 style={{ fontSize: '18px', fontWeight: 600, color: '#111827', marginBottom: '8px' }}>No records yet</h2>
+            <p style={{ color: '#6b7280' }}>Completed consultations and prescriptions will appear here.</p>
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            {appointments.map((appt) => {
+              const isOpen = expanded === appt.id
+              const date = new Date(appt.slot.startTime)
+
+              return (
+                <div key={appt.id} style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', overflow: 'hidden' }}>
+                  <button
+                    onClick={() => setExpanded(isOpen ? null : appt.id)}
+                    style={{ width: '100%', padding: '20px 24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: 'none', border: 'none', cursor: 'pointer', textAlign: 'left' }}
+                  >
+                    <div>
+                      <p style={{ fontSize: '16px', fontWeight: 700, color: '#111827', margin: '0 0 4px' }}>{appt.doctor.name}</p>
+                      <p style={{ fontSize: '13px', color: '#6b7280', margin: 0 }}>
+                        {appt.doctor.specialization} · {date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
+                      </p>
+                    </div>
+                    {isOpen ? <ChevronUp size={18} color="#6b7280" /> : <ChevronDown size={18} color="#6b7280" />}
+                  </button>
+
+                  {isOpen && (
+                    <div style={{ padding: '0 24px 24px', borderTop: '1px solid #f3f4f6' }}>
+                      {!appt.record ? (
+                        <p style={{ color: '#9ca3af', fontSize: '14px', paddingTop: '20px', margin: 0 }}>No consultation notes added yet.</p>
+                      ) : (
+                        <>
+                          {appt.record.notes && (
+                            <div style={{ paddingTop: '20px', marginBottom: '20px' }}>
+                              <h4 style={{ fontSize: '13px', fontWeight: 600, color: '#374151', textTransform: 'uppercase', letterSpacing: '0.05em', margin: '0 0 8px' }}>Consultation Notes</h4>
+                              <p style={{ fontSize: '14px', color: '#4b5563', lineHeight: 1.7, margin: 0, whiteSpace: 'pre-line' }}>{appt.record.notes}</p>
+                            </div>
+                          )}
+
+                          {appt.record.prescriptions.length > 0 && (
+                            <div>
+                              <h4 style={{ fontSize: '13px', fontWeight: 600, color: '#374151', textTransform: 'uppercase', letterSpacing: '0.05em', margin: '0 0 12px' }}>
+                                Prescriptions ({appt.record.prescriptions.length})
+                              </h4>
+                              <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+                                {appt.record.prescriptions.map((rx) => (
+                                  <div key={rx.id} style={{ background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '8px', padding: '14px 16px' }}>
+                                    <p style={{ fontSize: '14px', fontWeight: 700, color: '#111827', margin: '0 0 6px' }}>{rx.medicationName}</p>
+                                    <p style={{ fontSize: '13px', color: '#6b7280', margin: 0, lineHeight: 1.5 }}>
+                                      {rx.dosage} · {rx.frequency} · {rx.duration}
+                                    </p>
+                                    {rx.notes && <p style={{ fontSize: '13px', color: '#9ca3af', margin: '4px 0 0', fontStyle: 'italic' }}>{rx.notes}</p>}
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/apps/web/src/app/doctors/[id]/page.tsx
+++ b/apps/web/src/app/doctors/[id]/page.tsx
@@ -1,0 +1,237 @@
+'use client'
+
+import { useState, useEffect, use } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@clerk/nextjs'
+import { User, Calendar, Clock, ArrowLeft } from 'lucide-react'
+import { apiFetch } from '@/lib/api'
+
+interface Doctor {
+  id: string
+  name: string
+  specialization: string
+  bio: string | null
+  profilePictureUrl: string | null
+  contactDetails: string | null
+}
+
+interface Slot {
+  id: string
+  startTime: string
+  endTime: string
+}
+
+function groupByDate(slots: Slot[]): Record<string, Slot[]> {
+  return slots.reduce((acc, slot) => {
+    const date = new Date(slot.startTime).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
+    if (!acc[date]) acc[date] = []
+    acc[date].push(slot)
+    return acc
+  }, {} as Record<string, Slot[]>)
+}
+
+export default function DoctorDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
+  const router = useRouter()
+  const { getToken, isSignedIn } = useAuth()
+
+  const [doctor, setDoctor] = useState<Doctor | null>(null)
+  const [slots, setSlots] = useState<Slot[]>([])
+  const [selectedSlot, setSelectedSlot] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [booking, setBooking] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [doctorRes, slotsRes] = await Promise.all([
+          fetch(`/api/doctors/${id}`),
+          fetch(`/api/doctors/${id}/availability`),
+        ])
+        if (doctorRes.ok) setDoctor(await doctorRes.json())
+        if (slotsRes.ok) setSlots(await slotsRes.json())
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [id])
+
+  async function handleBook() {
+    if (!selectedSlot) return
+    if (!isSignedIn) {
+      router.push('/sign-in')
+      return
+    }
+
+    setBooking(true)
+    setError('')
+    try {
+      const token = await getToken()
+      await apiFetch('/appointments', {
+        token: token || undefined,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slotId: selectedSlot }),
+      })
+      setSuccess(true)
+      setTimeout(() => router.push('/dashboard/patient/appointments'), 1500)
+    } catch (err: any) {
+      setError(err.message || 'Booking failed. Please try again.')
+    } finally {
+      setBooking(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh', fontFamily: "'Segoe UI', system-ui, sans-serif" }}>
+        <p style={{ color: '#6b7280' }}>Loading...</p>
+      </div>
+    )
+  }
+
+  if (!doctor) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh', fontFamily: "'Segoe UI', system-ui, sans-serif" }}>
+        <p style={{ color: '#6b7280' }}>Doctor not found.</p>
+      </div>
+    )
+  }
+
+  const grouped = groupByDate(slots)
+
+  return (
+    <div style={{ fontFamily: "'Segoe UI', system-ui, sans-serif", background: '#f9fafb', minHeight: '100vh', color: '#111827' }}>
+      <nav style={{ display: 'flex', alignItems: 'center', gap: '16px', padding: '16px 40px', background: '#ffffff', borderBottom: '1px solid #e5e7eb', position: 'sticky', top: 0, zIndex: 10 }}>
+        <button onClick={() => router.back()} style={{ display: 'flex', alignItems: 'center', gap: '6px', background: 'none', border: 'none', cursor: 'pointer', fontSize: '14px', fontWeight: 500, color: '#6b7280' }}>
+          <ArrowLeft size={16} /> Back
+        </button>
+        <span style={{ fontSize: '18px', fontWeight: 700, color: '#111827', letterSpacing: '-0.5px' }}>LunaSol</span>
+      </nav>
+
+      <main style={{ maxWidth: '900px', margin: '0 auto', padding: '40px 24px', display: 'grid', gridTemplateColumns: '1fr 360px', gap: '32px', alignItems: 'start' }}>
+        {/* Doctor info */}
+        <div>
+          <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '16px', padding: '32px', marginBottom: '24px' }}>
+            <div style={{ display: 'flex', gap: '24px', alignItems: 'flex-start', marginBottom: '24px' }}>
+              <div style={{
+                width: '80px', height: '80px', borderRadius: '50%', flexShrink: 0,
+                background: doctor.profilePictureUrl ? `url(${doctor.profilePictureUrl}) center/cover` : '#f3f4f6',
+                border: '2px solid #e5e7eb', display: 'flex', alignItems: 'center', justifyContent: 'center',
+              }}>
+                {!doctor.profilePictureUrl && <User size={32} color="#9ca3af" />}
+              </div>
+              <div>
+                <h1 style={{ fontSize: '24px', fontWeight: 700, margin: '0 0 8px', letterSpacing: '-0.5px' }}>{doctor.name}</h1>
+                <span style={{ fontSize: '13px', fontWeight: 600, color: '#059669', background: '#f0fdf4', padding: '4px 10px', borderRadius: '12px' }}>
+                  {doctor.specialization}
+                </span>
+              </div>
+            </div>
+
+            {doctor.bio && (
+              <div style={{ marginBottom: '20px' }}>
+                <h3 style={{ fontSize: '14px', fontWeight: 600, color: '#374151', marginBottom: '8px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>About</h3>
+                <p style={{ fontSize: '15px', color: '#4b5563', lineHeight: 1.7, margin: 0 }}>{doctor.bio}</p>
+              </div>
+            )}
+
+            {doctor.contactDetails && (
+              <div>
+                <h3 style={{ fontSize: '14px', fontWeight: 600, color: '#374151', marginBottom: '8px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Contact</h3>
+                <p style={{ fontSize: '14px', color: '#6b7280', lineHeight: 1.6, margin: 0, whiteSpace: 'pre-line' }}>{doctor.contactDetails}</p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Slot picker */}
+        <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '16px', padding: '24px', position: 'sticky', top: '80px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '20px' }}>
+            <Calendar size={18} color="#111827" />
+            <h2 style={{ fontSize: '16px', fontWeight: 700, margin: 0 }}>Available slots</h2>
+          </div>
+
+          {slots.length === 0 ? (
+            <div style={{ textAlign: 'center', padding: '32px 0' }}>
+              <Clock size={32} color="#d1d5db" style={{ margin: '0 auto 12px' }} />
+              <p style={{ color: '#9ca3af', fontSize: '14px', margin: 0 }}>No available slots in the next 14 days.</p>
+            </div>
+          ) : (
+            <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
+              {Object.entries(grouped).map(([date, daySlots]) => (
+                <div key={date} style={{ marginBottom: '20px' }}>
+                  <p style={{ fontSize: '12px', fontWeight: 600, color: '#6b7280', textTransform: 'uppercase', letterSpacing: '0.05em', margin: '0 0 8px' }}>{date}</p>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+                    {daySlots.map((slot) => {
+                      const start = new Date(slot.startTime).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
+                      const isSelected = selectedSlot === slot.id
+                      return (
+                        <button
+                          key={slot.id}
+                          onClick={() => setSelectedSlot(isSelected ? null : slot.id)}
+                          style={{
+                            padding: '6px 12px',
+                            border: `2px solid ${isSelected ? '#111827' : '#e5e7eb'}`,
+                            borderRadius: '8px',
+                            background: isSelected ? '#111827' : '#ffffff',
+                            color: isSelected ? '#ffffff' : '#374151',
+                            fontSize: '13px',
+                            fontWeight: 600,
+                            cursor: 'pointer',
+                          }}
+                        >
+                          {start}
+                        </button>
+                      )
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {error && (
+            <div style={{ background: '#fef2f2', border: '1px solid #fecaca', borderRadius: '8px', padding: '10px 14px', marginBottom: '16px', color: '#dc2626', fontSize: '13px' }}>
+              {error}
+            </div>
+          )}
+
+          {success && (
+            <div style={{ background: '#f0fdf4', border: '1px solid #86efac', borderRadius: '8px', padding: '10px 14px', marginBottom: '16px', color: '#166534', fontSize: '13px', fontWeight: 600 }}>
+              Appointment booked! Redirecting...
+            </div>
+          )}
+
+          <button
+            onClick={handleBook}
+            disabled={!selectedSlot || booking || success}
+            style={{
+              width: '100%',
+              padding: '12px',
+              background: selectedSlot && !booking && !success ? '#111827' : '#d1d5db',
+              border: 'none',
+              borderRadius: '8px',
+              color: '#ffffff',
+              fontSize: '14px',
+              fontWeight: 600,
+              cursor: selectedSlot && !booking && !success ? 'pointer' : 'not-allowed',
+              marginTop: '16px',
+            }}
+          >
+            {booking ? 'Booking...' : !isSignedIn ? 'Sign in to book' : 'Book appointment'}
+          </button>
+
+          {!isSignedIn && (
+            <p style={{ fontSize: '12px', color: '#9ca3af', textAlign: 'center', marginTop: '8px', marginBottom: 0 }}>
+              You need to be signed in to book.
+            </p>
+          )}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/apps/web/src/app/doctors/page.tsx
+++ b/apps/web/src/app/doctors/page.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { Search, Filter, User } from 'lucide-react'
+
+interface Doctor {
+  id: string
+  name: string
+  specialization: string
+  bio: string | null
+  profilePictureUrl: string | null
+  contactDetails: string | null
+}
+
+const SPECIALIZATIONS = [
+  'All',
+  'Cardiology',
+  'Dermatology',
+  'Family Medicine',
+  'General Medicine',
+  'Neurology',
+  'Orthopedics',
+  'Pediatrics',
+  'Psychiatry',
+]
+
+export default function DoctorsPage() {
+  const router = useRouter()
+  const [doctors, setDoctors] = useState<Doctor[]>([])
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [specialization, setSpecialization] = useState('All')
+  const [availableOnly, setAvailableOnly] = useState(false)
+
+  const fetchDoctors = useCallback(async () => {
+    setLoading(true)
+    const params = new URLSearchParams()
+    if (search) params.set('search', search)
+    if (specialization !== 'All') params.set('specialization', specialization)
+    if (availableOnly) params.set('available', 'true')
+
+    try {
+      const res = await fetch(`/api/doctors?${params}`)
+      if (res.ok) setDoctors(await res.json())
+    } finally {
+      setLoading(false)
+    }
+  }, [search, specialization, availableOnly])
+
+  useEffect(() => {
+    const t = setTimeout(fetchDoctors, 300)
+    return () => clearTimeout(t)
+  }, [fetchDoctors])
+
+  return (
+    <div style={{ fontFamily: "'Segoe UI', system-ui, sans-serif", background: '#f9fafb', minHeight: '100vh', color: '#111827' }}>
+      <nav style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '16px 40px', background: '#ffffff', borderBottom: '1px solid #e5e7eb', position: 'sticky', top: 0, zIndex: 10 }}>
+        <a href="/" style={{ fontSize: '18px', fontWeight: 700, color: '#111827', textDecoration: 'none', letterSpacing: '-0.5px' }}>LunaSol</a>
+        <div style={{ display: 'flex', gap: '16px' }}>
+          <a href="/sign-in" style={{ padding: '8px 16px', border: '1px solid #d1d5db', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#374151', textDecoration: 'none' }}>Sign In</a>
+          <a href="/sign-up" style={{ padding: '8px 16px', background: '#111827', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#ffffff', textDecoration: 'none' }}>Sign Up</a>
+        </div>
+      </nav>
+
+      <main style={{ maxWidth: '1200px', margin: '0 auto', padding: '40px 24px' }}>
+        <div style={{ marginBottom: '32px' }}>
+          <h1 style={{ fontSize: '28px', fontWeight: 700, color: '#111827', margin: '0 0 8px', letterSpacing: '-0.5px' }}>Find a Doctor</h1>
+          <p style={{ fontSize: '16px', color: '#6b7280', margin: 0 }}>Browse our network of licensed healthcare professionals.</p>
+        </div>
+
+        {/* Filters */}
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '32px', flexWrap: 'wrap' }}>
+          <div style={{ position: 'relative', flex: '1', minWidth: '240px' }}>
+            <Search size={16} color="#9ca3af" style={{ position: 'absolute', left: '12px', top: '50%', transform: 'translateY(-50%)' }} />
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search by name or specialization..."
+              style={{ width: '100%', padding: '10px 12px 10px 36px', border: '1px solid #d1d5db', borderRadius: '8px', fontSize: '14px', boxSizing: 'border-box' }}
+            />
+          </div>
+
+          <div style={{ position: 'relative' }}>
+            <Filter size={16} color="#9ca3af" style={{ position: 'absolute', left: '12px', top: '50%', transform: 'translateY(-50%)' }} />
+            <select
+              value={specialization}
+              onChange={(e) => setSpecialization(e.target.value)}
+              style={{ padding: '10px 12px 10px 36px', border: '1px solid #d1d5db', borderRadius: '8px', fontSize: '14px', background: '#ffffff', cursor: 'pointer', minWidth: '180px' }}
+            >
+              {SPECIALIZATIONS.map((s) => <option key={s}>{s}</option>)}
+            </select>
+          </div>
+
+          <label style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '10px 16px', border: '1px solid #d1d5db', borderRadius: '8px', cursor: 'pointer', fontSize: '14px', fontWeight: 500, color: '#374151', background: availableOnly ? '#f0fdf4' : '#ffffff', borderColor: availableOnly ? '#86efac' : '#d1d5db' }}>
+            <input type="checkbox" checked={availableOnly} onChange={(e) => setAvailableOnly(e.target.checked)} style={{ accentColor: '#10b981' }} />
+            Available now
+          </label>
+        </div>
+
+        {/* Results */}
+        {loading ? (
+          <div style={{ textAlign: 'center', padding: '60px', color: '#9ca3af' }}>Loading doctors...</div>
+        ) : doctors.length === 0 ? (
+          <div style={{ textAlign: 'center', padding: '60px' }}>
+            <User size={48} color="#d1d5db" style={{ margin: '0 auto 16px' }} />
+            <p style={{ color: '#6b7280', fontSize: '16px' }}>No doctors found matching your search.</p>
+          </div>
+        ) : (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))', gap: '20px' }}>
+            {doctors.map((doctor) => (
+              <div
+                key={doctor.id}
+                onClick={() => router.push(`/doctors/${doctor.id}`)}
+                style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '24px', cursor: 'pointer', transition: 'box-shadow 0.15s', boxShadow: '0 1px 3px rgba(0,0,0,0.04)' }}
+                onMouseEnter={(e) => (e.currentTarget.style.boxShadow = '0 4px 12px rgba(0,0,0,0.08)')}
+                onMouseLeave={(e) => (e.currentTarget.style.boxShadow = '0 1px 3px rgba(0,0,0,0.04)')}
+              >
+                <div style={{ display: 'flex', gap: '16px', alignItems: 'flex-start', marginBottom: '16px' }}>
+                  <div style={{
+                    width: '52px', height: '52px', borderRadius: '50%', flexShrink: 0,
+                    background: doctor.profilePictureUrl ? `url(${doctor.profilePictureUrl}) center/cover` : '#f3f4f6',
+                    border: '2px solid #e5e7eb',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  }}>
+                    {!doctor.profilePictureUrl && <User size={20} color="#9ca3af" />}
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <h3 style={{ fontSize: '16px', fontWeight: 700, margin: '0 0 4px', color: '#111827' }}>{doctor.name}</h3>
+                    <span style={{ fontSize: '12px', fontWeight: 600, color: '#059669', background: '#f0fdf4', padding: '2px 8px', borderRadius: '12px' }}>
+                      {doctor.specialization}
+                    </span>
+                  </div>
+                </div>
+                {doctor.bio && (
+                  <p style={{ fontSize: '14px', color: '#6b7280', margin: '0 0 16px', lineHeight: 1.5, display: '-webkit-box', WebkitLineClamp: 3, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>
+                    {doctor.bio}
+                  </p>
+                )}
+                <div style={{ borderTop: '1px solid #f3f4f6', paddingTop: '16px', display: 'flex', justifyContent: 'flex-end' }}>
+                  <span style={{ fontSize: '13px', fontWeight: 600, color: '#111827' }}>View profile →</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

End-to-end patient journey from finding a doctor to viewing medical records.

### Backend
- **#16** `GET /api/doctors` now accepts `?search=`, `?specialization=`, `?available=true` — text search across name/specialization, availability filter checks for open slots in next 14 days
- **#16** `GET /api/doctors/:id/availability` — returns non-blocked, non-booked slots for the next 14 days
- **#21** Full `AppointmentsModule`: book, cancel, reschedule (patient); confirm + generate Jitsi room, complete (doctor); `GET /appointments/mine` works for both roles; creates `Notification` DB records on every state change

> ⚠️ **Real-time notifications blocked on #9** — appointment state changes persist to the `Notification` table but Socket.io emission is not yet wired in. Integration point is marked with a TODO in `AppointmentsService.createNotification`. Will be completed once the Socket.io gateway (#9) and notification center UI (#10) land.

### Frontend
- **#17** `/doctors` — doctor grid with live search, specialization dropdown, available-only toggle
- **#17** `/doctors/:id` — doctor profile + slot picker; books via `POST /api/appointments`
- **#22** `/dashboard/patient/appointments` — upcoming/past list, inline cancel, Join Session button for confirmed appointments
- **#23** `/dashboard/patient/records` — expandable completed consultations with notes and prescriptions
- Patient dashboard nav links wired to all new pages

### Bug fixes (post-review)
- `book()` and `reschedule()` wrapped in `prisma.$transaction` — prevents double-booking under concurrent requests; P2002 caught as 409
- Patient `listMine` now includes `record + prescriptions` — records page was always showing empty
- `ensurePatientRecord` now syncs role to Clerk `publicMetadata` (was missing, unlike the doctor equivalent)
- Dashboard redirect now handles 403 alongside 404/401 to catch role-mismatch before onboarding
- Fixed object URL memory leak in `ProfileForm` (revoke on re-select and unmount)

## Test plan
- [ ] Browse `/doctors` — all doctors listed; search filters in real time
- [ ] Filter by specialization + available only — results narrow correctly
- [ ] Click doctor → detail page with available slots shown
- [ ] Select a slot and book → redirected to appointments page, appointment shows as PENDING
- [ ] Book the same slot twice simultaneously → second request returns 409
- [ ] Cancel appointment → status changes to CANCELLED
- [ ] Doctor confirms → status CONFIRMED, Join Session button appears
- [ ] Visit `/dashboard/patient/records` after doctor completes a session → notes and prescriptions visible
- [ ] `GET /api/doctors` with no auth → 200
- [ ] `POST /api/appointments` with doctor JWT → 403
- [ ] Book already-taken slot → 409