### PR TITLE
fix(docker): build @lunasol/types before api and web prod builds

### DIFF
--- a/apps/api/Dockerfile.prod
+++ b/apps/api/Dockerfile.prod
@@ -16,6 +16,9 @@ COPY tsconfig.base.json ./
 COPY packages/types ./packages/types
 COPY apps/api ./apps/api
 
+WORKDIR /app
+RUN pnpm --filter @lunasol/types build
+
 WORKDIR /app/apps/api
 RUN /app/node_modules/.bin/prisma generate
 RUN pnpm build

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -16,6 +16,9 @@ COPY tsconfig.base.json ./
 COPY packages/types ./packages/types
 COPY apps/web ./apps/web
 
+WORKDIR /app
+RUN pnpm --filter @lunasol/types build
+
 WORKDIR /app/apps/web
 ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY


### PR DESCRIPTION
## Summary
- Fixes CI build failure where `nest build` could not resolve `@lunasol/types` (TS2307)
- Root cause: `packages/types` source was copied into the Docker build stage but never compiled, so `dist/` didn't exist
- Added `pnpm --filter @lunasol/types build` before the app build step in both `apps/api/Dockerfile.prod` and `apps/web/Dockerfile.prod`

## Test plan
- [ ] Verify CI build passes on this PR (the failing job was `Build images` → `api builder` → `RUN pnpm build`)