### PR TITLE
Release: AI triage, notifications, testing, Docker fixes

### DIFF
--- a/apps/ai/Dockerfile.prod
+++ b/apps/ai/Dockerfile.prod
@@ -1,24 +1,3 @@
-# Stage 1: Build wheels
-FROM nvidia/cuda:12.2.0-devel-ubuntu22.04 AS builder
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3-pip \
-    python3-dev \
-    build-essential \
-    git \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /build
-
-# Build llama-cpp-python with CUDA support
-ENV CMAKE_ARGS="-DGGML_CUDA=on"
-RUN pip3 install --upgrade pip
-RUN pip3 install wheel
-
-COPY requirements.txt .
-RUN pip3 wheel --wheel-dir=/build/wheels -r requirements.txt
-
-# Stage 2: Final runner image
 FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -28,9 +7,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Copy and install wheels compiled with CUDA
-COPY --from=builder /build/wheels /wheels
-RUN pip3 install --no-cache-dir /wheels/*.whl && rm -rf /wheels
+COPY requirements.txt .
+# Pre-built CUDA wheel avoids ~10min nvcc compilation from the devel image
+RUN pip3 install --no-cache-dir \
+    --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu122 \
+    -r requirements.txt
 
 COPY . .
 

--- a/apps/ai/Dockerfile.prod
+++ b/apps/ai/Dockerfile.prod
@@ -3,6 +3,7 @@ FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
+    libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,17 +1,10 @@
 import { clerkMiddleware } from '@clerk/nextjs/server'
 
-// frontendApiProxy only works with production Clerk instances (pk_live_*).
-// Dev instances use Clerk's standard dev-browser redirect mechanism instead.
-const isProduction = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY?.startsWith('pk_live_')
-
-export default clerkMiddleware(
-  isProduction ? { frontendApiProxy: { enabled: true, path: '/__clerk' } } : {},
-)
+export default clerkMiddleware()
 
 export const config = {
   matcher: [
     '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     '/(api|trpc)(.*)',
-    '/__clerk/(.*)',
   ],
 }

--- a/doc/README.md
+++ b/doc/README.md
@@ -12,8 +12,9 @@ This directory documents the design decisions behind LunaSol. Each file covers o
 | [api.md](./api.md)                     | REST conventions, module structure, error handling, DTOs    |
 | [ai-service.md](./ai-service.md)       | Local GGUF inference, FastAPI design, SSE streaming chain   |
 | [notifications.md](./notifications.md) | Socket.io gateway, room model, event catalog                |
-| [video.md](./video.md)                 | Jitsi self-hosted setup, room auth, session lifecycle       |
+| [video.md](./video.md)                 | LiveKit self-hosted setup, room auth, session lifecycle     |
 | [deployment.md](./deployment.md)       | Docker, Nginx, Cloudflare Tunnel, CI/CD pipeline            |
 | [frontend.md](./frontend.md)           | Next.js App Router, Shadcn, routing, data fetching patterns |
 | [testing.md](./testing.md)             | Vitest, Jest, Playwright, Pytest, architecture, setup flows  |
+| [roadmap.md](./roadmap.md)             | Feature checklist — done, in progress, backlog              |
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -16,7 +16,7 @@ LunaSol is a full-stack telehealth web application split across three runtime se
 [Nginx :80]
     ├── /          →  web      (Next.js   :3000)
     ├── /api/*     →  api      (NestJS    :3001)   ← WebSocket upgrade for Socket.io
-    ├── /meet/*    →  jitsi    (Jitsi     :8443)   ← WebSocket upgrade
+    ├── /meet/*    →  livekit  (LiveKit   :7880)   ← WebSocket upgrade
     └── /pgadmin   →  pgadmin  (pgAdmin   :5050)
 
 [api] ── internal Docker network ──► [ai]       (FastAPI   :8000)   ← never public

--- a/doc/data-model.md
+++ b/doc/data-model.md
@@ -65,7 +65,7 @@ erDiagram
         string doctorId FK
         string slotId FK, UK
         AppointmentStatus status
-        string jitsiRoom
+        string livekitRoom
         datetime createdAt
         datetime updatedAt
     }
@@ -159,7 +159,7 @@ patientId       String    FK → PatientProfile
 doctorId        String    FK → DoctorProfile
 slotId          String    FK → AvailabilitySlot
 status          AppointmentStatus  (PENDING | CONFIRMED | CANCELLED | COMPLETED)
-jitsiRoom       String?
+livekitRoom     String?
 createdAt       DateTime
 updatedAt       DateTime
 ```
@@ -214,9 +214,9 @@ Availability could have been modeled as a simple schedule config (e.g., "Mondays
 - Booked slots need to reference a specific slot ID on the Appointment
 - Querying available slots for a date range is a simple `WHERE isBlocked = false AND id NOT IN (booked slots)`
 
-### jitsiRoom stored on Appointment, not a separate table
+### livekitRoom stored on Appointment, not a separate table
 
-A Jitsi room name is a short string (`appt-<uuid>`) generated once when the appointment is confirmed. There's no additional metadata to store, no lifecycle of its own, and no need to join to another table. Storing it directly on `Appointment` is the simplest correct approach.
+A LiveKit room name is a short string (`appt-<uuid>`) generated once when the appointment is confirmed. There's no additional metadata to store, no lifecycle of its own, and no need to join to another table. Storing it directly on `Appointment` is the simplest correct approach.
 
 ### Appointment status uses an enum, not a boolean
 

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -5,7 +5,7 @@
 **Why Docker:**
 
 - Reproducible builds — identical environment in dev and production
-- All services (Next.js, NestJS, FastAPI, Postgres, Jitsi, Nginx, pgAdmin) are orchestrated with a single `docker compose` command
+- All services (Next.js, NestJS, FastAPI, Postgres, LiveKit, Nginx, pgAdmin) are orchestrated with a single `docker compose` command
 - Easy to restart, update, or replace individual services without touching others
 - `docker-compose.yml` (dev) and `docker-compose.prod.yml` (prod) share service definitions with environment-specific overrides
 
@@ -29,7 +29,7 @@
 | `ai`          | FastAPI + llama-cpp    | internal          | No                   |
 | `db`          | postgres:16            | internal          | No                   |
 | `pgadmin`     | dpage/pgadmin4         | internal          | Via Nginx `/pgadmin` |
-| `jitsi`       | jitsi stack            | internal          | Via Nginx `/meet`    |
+| `livekit`     | livekit/livekit-server | internal          | Via Nginx `/meet`    |
 | `nginx`       | nginx:alpine           | internal + tunnel | Entry point          |
 | `cloudflared` | cloudflare/cloudflared | internal          | Tunnel daemon        |
 
@@ -56,7 +56,7 @@ server {
     }
 
     location /meet {
-        proxy_pass https://jitsi:8443;
+        proxy_pass http://livekit:7880;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -105,7 +105,8 @@ All secrets live in `.env.prod` on the server — never in the repository.
 | `DATABASE_URL`             | NestJS / Prisma                |
 | `CLERK_SECRET_KEY`         | NestJS auth guard + webhook    |
 | `CLERK_WEBHOOK_SECRET`     | Webhook signature verification |
-| `JITSI_JWT_SECRET`         | Room token signing             |
+| `LIVEKIT_API_KEY`          | Room token signing key name    |
+| `LIVEKIT_API_SECRET`       | Room token signing secret      |
 | `PGADMIN_DEFAULT_EMAIL`    | pgAdmin login                  |
 | `PGADMIN_DEFAULT_PASSWORD` | pgAdmin login                  |
 | `CLOUDFLARE_TUNNEL_TOKEN`  | cloudflared tunnel daemon      |

--- a/doc/roadmap.md
+++ b/doc/roadmap.md
@@ -1,0 +1,75 @@
+# Roadmap
+
+Progress against the planned feature set. Updated as of the current state of `main`.
+
+---
+
+## Done
+
+### Infrastructure & Auth
+- [x] Docker Compose (dev + prod), Nginx reverse proxy, Cloudflare Tunnel
+- [x] CI/CD pipeline — GitHub Actions → SSH → `docker compose --build` + Prisma migrate
+- [x] Clerk auth — JWT guard, role model (`doctor` / `patient`), webhook sync, `publicMetadata` propagation
+- [x] Role-based guards (`@Roles`, `@Public`) applied globally via `APP_GUARD`
+
+### Onboarding & Profiles
+- [x] Patient onboarding flow + profile API (`/api/patients/me`)
+- [x] Doctor onboarding flow + profile API (`/api/doctors/me`) with profile picture upload
+- [x] `profileComplete` flag gates dashboard redirect for both roles
+
+### Appointments
+- [x] Doctor availability slots API (create, list, block)
+- [x] Doctor listing API with filters (specialization, name) and availability endpoint
+- [x] Appointment management API — book, confirm, cancel, complete; status-only, no hard deletes
+- [x] Doctor discovery + detail pages (patient UI)
+- [x] Appointment booking flow UI (patient UI)
+- [x] Patient appointments list + appointment detail page
+- [x] Patient medical records page (consultation records + prescriptions, read-only)
+
+### Notifications
+- [x] Socket.io gateway with per-user rooms
+- [x] `appointment.booked` / `appointment.status_changed` events emitted from appointments service
+- [x] Notification bell UI with unread count badge and dropdown (real-time updates)
+- [x] Notification persistence in DB
+
+### AI Triage
+- [x] FastAPI inference service — MedGemma 1.5 4B IQ4_XS, full GPU offload, GGUF via llama-cpp-python
+- [x] `POST /recommend` SSE endpoint — streams model output token-by-token
+- [x] NestJS SSE relay — fetches doctors from DB, pipes FastAPI stream to browser, appends matched doctor objects in final event
+- [x] Offline fallback — keyword + Levenshtein fuzzy matching when AI service is unavailable
+- [x] Pre-built CUDA wheel install (no nvcc compilation in Docker build)
+
+### Testing
+- [x] Unit testing setup — Vitest (web), Jest (api), Pytest (ai)
+- [x] Integration test setup — NestJS supertest against a real DB
+- [x] E2E setup — Playwright
+
+---
+
+## In Progress / Up Next
+
+### Video Consultation (LiveKit)
+- [ ] `GET /api/appointments/:id/livekit-token` — server-side token generation via `livekit-server-sdk`, scoped to appointment room, 15 min TTL
+- [ ] `livekitRoom` field population on appointment confirm
+- [ ] Patient consultation room UI — `@livekit/components-react` inside the appointment detail page
+- [ ] Doctor consultation room UI — join/leave, post-session prompt for notes
+
+### Doctor Dashboard
+- [ ] Doctor appointments list (upcoming, past)
+- [ ] Appointment detail page (doctor view) — confirm/complete actions, patient info
+
+### Consultation Records & Prescriptions
+- [ ] `POST /api/consultations` — create record after session ends (doctor only)
+- [ ] `POST /api/consultations/:id/prescriptions` — add prescription to record
+- [ ] Doctor-side UI for post-consultation notes and prescription entry
+
+---
+
+## Backlog
+
+- [ ] Email notifications (appointment reminders)
+- [ ] Appointment rescheduling flow
+- [ ] Doctor calendar view (week/month grid)
+- [ ] Patient search by symptom (surface AI recommendations on the discovery page)
+- [ ] Admin panel (beyond pgAdmin — user management, audit log)
+- [ ] LiveKit Egress for session recording (opt-in, consent required)

--- a/doc/video.md
+++ b/doc/video.md
@@ -1,38 +1,39 @@
 # Video Consultation
 
-## Decision: Self-Hosted Jitsi over Daily.co / Agora / Twilio
+## Decision: Self-Hosted LiveKit over Jitsi / Daily.co / Agora / Twilio
 
 | Option            | Cost                 | Control | Complexity |
 | ----------------- | -------------------- | ------- | ---------- |
 | Daily.co          | Paid after free tier | Low     | Low        |
 | Agora             | 10k min/month free   | Medium  | Medium     |
-| Jitsi self-hosted | Free (self-hosted)   | Full    | Medium     |
+| Jitsi self-hosted | Free (self-hosted)   | Full    | Medium-high|
+| LiveKit self-hosted | Free (self-hosted) | Full    | Medium     |
 | Custom WebRTC     | Free                 | Full    | Very high  |
 
-**Why Jitsi:**
+**Why LiveKit:**
 
 - Completely free — no usage limits, no external billing
-- Runs in Docker on the same server — no third-party data handling
-- JWT room authentication is built-in — rooms can be locked to specific participants
+- Single Docker container vs. Jitsi's four (web, prosody, jicofo, jvb)
+- ~150 MB RAM idle vs. Jitsi's ~1.5–2 GB — fits the server's memory budget
+- JWT room authentication built-in — rooms locked to specific participants
+- First-class NestJS SDK (`livekit-server-sdk`) and React SDK (`@livekit/components-react`)
+- React components are native — no iframe, consultation UI lives inside the app
+- Built-in TURN support — no manual UDP port configuration
 - Open source and actively maintained
-- Fits the self-hosted deployment model already chosen for the rest of the stack
 
-**Trade-off accepted:** Jitsi requires four Docker containers (web, prosody, jicofo, jvb) instead of a single API call. This adds configuration overhead, particularly for the video bridge (JVB) which requires careful network config for peer-to-peer relay.
+**Trade-off accepted:** LiveKit's Egress service (for recording/transcription) is a separate container if needed. For 1-on-1 consultations without recording, the single `livekit` container is sufficient.
 
 ---
 
-## Jitsi Docker Stack
+## LiveKit Docker Stack
 
-Four services work together:
+One service handles everything:
 
-| Container       | Role                                |
-| --------------- | ----------------------------------- |
-| `jitsi/web`     | Jitsi Meet web interface            |
-| `jitsi/prosody` | XMPP server — handles signalling    |
-| `jitsi/jicofo`  | Conference focus — manages sessions |
-| `jitsi/jvb`     | Video bridge — relays media streams |
+| Container  | Role                                      |
+| ---------- | ----------------------------------------- |
+| `livekit`  | SFU — handles signalling, media relay, TURN |
 
-All four are on the internal Docker network. Only `jitsi/web` is accessible externally via Nginx at `/meet/*`.
+Exposed internally only. Nginx proxies WebSocket connections at `/meet/*` to the LiveKit server.
 
 ---
 
@@ -40,43 +41,45 @@ All four are on the internal Docker network. Only `jitsi/web` is accessible exte
 
 ```
 Appointment status → CONFIRMED
-  → NestJS generates jitsiRoom = "appt-<uuid>"
-  → Stored on Appointment.jitsiRoom
+  → NestJS generates livekitRoom = "appt-<uuid>"
+  → Stored on Appointment.livekitRoom
   → Patient and doctor see "Join Session" button on their appointment detail page
 
 User clicks "Join Session"
-  → Frontend calls GET /api/appointments/:id/jitsi-token
+  → Frontend calls GET /api/appointments/:id/livekit-token
   → NestJS verifies the requesting user is the patient or doctor for this appointment
-  → NestJS generates a short-lived JWT signed with JITSI_JWT_SECRET
-  → Frontend opens /meet/<jitsiRoom>?jwt=<token>
-  → Jitsi validates the JWT before admitting the user
+  → NestJS generates a short-lived token signed with LIVEKIT_API_SECRET
+  → Frontend connects to LiveKit using @livekit/components-react with the token
+  → LiveKit validates the token before admitting the user
 ```
 
 ---
 
 ## JWT Room Auth
 
-Jitsi is configured with `ENABLE_AUTH=1` and `AUTH_TYPE=jwt`. Every user joining a room must present a valid JWT.
+LiveKit uses API key + secret for token signing. Every participant joining a room must present a valid access token.
 
-JWT payload:
+Token is generated server-side using `livekit-server-sdk`:
 
-```json
-{
-  "sub": "meet.<your-domain>",
-  "iss": "lunasol",
-  "aud": "jitsi",
-  "room": "appt-<uuid>",
-  "exp": <15 minutes from now>,
-  "context": {
-    "user": {
-      "name": "John Patient",
-      "email": "john@example.com"
-    }
-  }
-}
+```ts
+import { AccessToken } from 'livekit-server-sdk';
+
+const token = new AccessToken(LIVEKIT_API_KEY, LIVEKIT_API_SECRET, {
+  identity: userId,
+  name: displayName,
+  ttl: '15m',
+});
+token.addGrant({ room: `appt-${appointmentId}`, roomJoin: true, canPublish: true, canSubscribe: true });
+const jwt = await token.toJwt();
 ```
 
-Signed with `JITSI_JWT_SECRET` (HS256). Jitsi validates the signature and the `room` claim — a token for `appt-abc` cannot be used to join `appt-xyz`.
+Token claims:
+- `room` — scoped to the specific appointment room (`appt-<uuid>`)
+- `identity` — the participant's userId
+- `canPublish` / `canSubscribe` — explicit media permissions per participant
+- `ttl` — 15 minutes from generation
+
+A token for `appt-abc` cannot be used to join `appt-xyz`.
 
 **Why short-lived tokens (15 min):**
 Users should only be able to join within a reasonable window of the scheduled time. A 15-minute TTL means the token is usable when the session starts but expires before the next appointment slot.
@@ -85,4 +88,14 @@ Users should only be able to join within a reasonable window of the scheduled ti
 
 ## Session End
 
-When the doctor leaves the session, the frontend detects the `participantLeft` event and prompts the doctor to add post-consultation notes. The Jitsi room continues to exist until the last participant leaves — there is no server-side "close room" call needed.
+When the doctor leaves the session, the `useRoomContext()` hook fires a `disconnected` event. The frontend prompts the doctor to add post-consultation notes. The LiveKit room is automatically cleaned up once all participants leave — no server-side close call needed.
+
+---
+
+## Environment Variables
+
+| Variable             | Purpose                          |
+| -------------------- | -------------------------------- |
+| `LIVEKIT_API_KEY`    | Token signing key name           |
+| `LIVEKIT_API_SECRET` | Token signing secret             |
+| `LIVEKIT_URL`        | WebSocket URL (`ws://livekit:7880`) used by the frontend |


### PR DESCRIPTION
## Summary
- feat: AI symptom triage with MedGemma 1.5 4B — SSE streaming, chat history, offline fuzzy fallback
- feat: real-time Socket.io notifications gateway + bell UI
- feat: patient appointments UI, doctor discovery, medical records page
- fix: pre-built llama-cpp-python CUDA wheel (no more nvcc compilation)
- fix: install libgomp1 in ai image for llama-cpp-python shared library
- fix: build @lunasol/types before api and web prod builds
- fix: remove broken Clerk frontend proxy middleware
- docs: roadmap, LiveKit migration, AI service, deployment updates

## Test plan
- [ ] CI build passes on all three images (web, api, ai)
- [ ] AI service starts without libgomp or @lunasol/types errors
- [ ] Doctor recommendation SSE stream works end-to-end
- [ ] Notifications appear in real time on appointment booking