### PR TITLE
fix(docker): install llama-cpp-python 0.3.23 from direct cu122 wheel URL

### DIFF
--- a/apps/ai/Dockerfile.prod
+++ b/apps/ai/Dockerfile.prod
@@ -9,10 +9,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY requirements.txt .
-# Pre-built CUDA wheel avoids ~10min nvcc compilation from the devel image
+# Install pre-built CUDA 12.2 wheel directly — 0.3.23 is the latest release with a cu122 build
+# and no cu122 wheel exists for older versions. Dev uses build-essential to compile from source.
 RUN pip3 install --no-cache-dir \
-    --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu122 \
-    -r requirements.txt
+    "https://github.com/abetlen/llama-cpp-python/releases/download/v0.3.23-cu122/llama_cpp_python-0.3.23-py3-none-linux_x86_64.whl"
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/apps/ai/requirements.txt
+++ b/apps/ai/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.115.12
 uvicorn[standard]==0.34.2
-llama-cpp-python==0.3.9
+llama-cpp-python==0.3.23
 pydantic==2.11.4
 python-dotenv==1.1.0
 pytest==8.0.0


### PR DESCRIPTION
## Summary
- Fixes CI build failure: `llama-cpp-python==0.3.9` has no pre-built cu122 release — pip was falling back to source compilation and failing on missing `ninja`
- Updates to `0.3.23`, the latest version with a cu122 build (`py3-none` universal wheel)
- Installs via direct GitHub release URL in `Dockerfile.prod` so the dev Dockerfile is unaffected

## Test plan
- [ ] CI `Build images` step passes for the `ai` image without compilation errors
- [ ] AI service starts and loads the model successfully