### PR TITLE
feat(ai): AI service toggle + GPU/CPU switch + memory tuning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,8 @@ AI_SERVICE_URL=http://ai:8000
 MODEL_PATH=/models/model.gguf
 MOCK_MODE=true
 N_GPU_LAYERS=-1
+# GPU device to use (default "0"). The CUDA-built llama.cpp aborts on load if
+# it can't fit a CUDA context, so when the GPU is busy with another workload
+# set this empty (CUDA_VISIBLE_DEVICES=) to fall back to CPU inference. On small
+# cards, pair GPU use with a lower N_GPU_LAYERS for partial offload.
+CUDA_VISIBLE_DEVICES=0

--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,11 @@ N_GPU_LAYERS=-1
 # set this empty (CUDA_VISIBLE_DEVICES=) to fall back to CPU inference. On small
 # cards, pair GPU use with a lower N_GPU_LAYERS for partial offload.
 CUDA_VISIBLE_DEVICES=0
+# Memory tuning. N_CTX caps context (KV cache scales with it; triage needs little).
+# FLASH_ATTN lowers attention memory and is required to quantize the V cache.
+# KV_CACHE_TYPE_{K,V}: f16 (default upstream) | q8_0 (~half, <0.1% quality) |
+# q4_0 (~quarter; fine on K, lossy on V). Recommended tight-VRAM combo: k=q4_0, v=q8_0.
+N_CTX=2048
+FLASH_ATTN=true
+KV_CACHE_TYPE_K=q8_0
+KV_CACHE_TYPE_V=q8_0

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ AI_PORT=8000
 PGADMIN_PORT=5050
 
 # ── AI Service ────────────────────────────────────────────────────────────────
+AI_ENABLED=true
 AI_SERVICE_URL=http://ai:8000
 MODEL_PATH=/models/model.gguf
 MOCK_MODE=true

--- a/apps/ai/src/model.py
+++ b/apps/ai/src/model.py
@@ -1,4 +1,5 @@
 import os
+import llama_cpp
 from llama_cpp import Llama
 
 model = None
@@ -6,24 +7,43 @@ model = None
 def get_model():
     return model
 
+def _ggml_type(name: str) -> int:
+    """Map a KV-cache type name (e.g. 'q8_0', 'q4_0', 'f16') to its ggml type id."""
+    try:
+        return getattr(llama_cpp, f"GGML_TYPE_{name.strip().upper()}")
+    except AttributeError:
+        raise RuntimeError(
+            f"Unknown KV cache type '{name}'. Use one of: f16, q8_0, q4_0, q5_0, q5_1."
+        )
+
 def load_model():
     global model
     mock_mode = os.getenv("MOCK_MODE", "false").lower() == "true"
     model_path = os.getenv("MODEL_PATH", "/models/model.gguf")
     n_gpu_layers = int(os.getenv("N_GPU_LAYERS", "-1"))
-    
+    n_ctx = int(os.getenv("N_CTX", "2048"))
+    flash_attn = os.getenv("FLASH_ATTN", "true").lower() == "true"
+    kv_k = os.getenv("KV_CACHE_TYPE_K", "q8_0")
+    kv_v = os.getenv("KV_CACHE_TYPE_V", "q8_0")
+
     if mock_mode:
         print("Starting in MOCK MODE - local LLM model will not be loaded.")
         return None
-        
-    print(f"Loading GGUF model from {model_path} with {n_gpu_layers} GPU layers...")
+
+    print(
+        f"Loading GGUF model from {model_path} with {n_gpu_layers} GPU layers, "
+        f"n_ctx={n_ctx}, flash_attn={flash_attn}, kv_cache=({kv_k}/{kv_v})..."
+    )
     if not os.path.exists(model_path):
         raise RuntimeError(f"Model file not found at path: {model_path}")
     try:
         model = Llama(
             model_path=model_path,
-            n_ctx=2048,
+            n_ctx=n_ctx,
             n_gpu_layers=n_gpu_layers,
+            flash_attn=flash_attn,
+            type_k=_ggml_type(kv_k),
+            type_v=_ggml_type(kv_v),
             verbose=False
         )
         print("Model loaded successfully!")

--- a/apps/api/src/ai/ai.service.ts
+++ b/apps/api/src/ai/ai.service.ts
@@ -9,6 +9,9 @@ export class AiService {
     payload: { symptoms?: string; messages?: { role: string; content: string }[] },
     doctors: AiDoctorSummary[]
   ): Promise<Response> {
+    if (process.env.AI_ENABLED === 'false') {
+      throw new InternalServerErrorException('AI service is disabled')
+    }
     try {
       const response = await fetch(`${this.aiServiceUrl}/recommend`, {
         method: 'POST',

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,6 +64,12 @@ services:
       # GPU is busy, set CUDA_VISIBLE_DEVICES="" to enumerate 0 devices and fall
       # back to CPU cleanly (the GPU reservation stays so libcuda.so.1 is linkable).
       - CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES-0}
+      # Memory tuning: short context + flash attention + quantized KV cache.
+      # q8_0 KV halves cache size at <0.1% quality cost (flash_attn required for V quant).
+      - N_CTX=${N_CTX:-2048}
+      - FLASH_ATTN=${FLASH_ATTN:-true}
+      - KV_CACHE_TYPE_K=${KV_CACHE_TYPE_K:-q8_0}
+      - KV_CACHE_TYPE_V=${KV_CACHE_TYPE_V:-q8_0}
     deploy:
       resources:
         reservations:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -58,6 +58,12 @@ services:
       - MODEL_PATH=/models/model.gguf
       - MOCK_MODE=${MOCK_MODE:-false}
       - N_GPU_LAYERS=${N_GPU_LAYERS:--1}
+      # Defaults to GPU 0. llama-cpp-python is CUDA-built and force-enumerates
+      # the GPU on load, hard-aborting (exit 139) if the CUDA context can't fit
+      # — e.g. when another workload is holding VRAM on a small card. When the
+      # GPU is busy, set CUDA_VISIBLE_DEVICES="" to enumerate 0 devices and fall
+      # back to CPU cleanly (the GPU reservation stays so libcuda.so.1 is linkable).
+      - CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES-0}
     deploy:
       resources:
         reservations:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,6 +30,7 @@ services:
       - CLERK_WEBHOOK_SECRET=${CLERK_WEBHOOK_SECRET}
       - NODE_ENV=production
       - AI_SERVICE_URL=http://ai:8000
+      - AI_ENABLED=${AI_ENABLED:-true}
     volumes:
       - uploads_data:/app/uploads
     depends_on:


### PR DESCRIPTION
Configurable runtime controls for the AI recommendation service, all env-driven (no rebuilds).

## Commits

### 1. `AI_ENABLED` toggle
- New `AI_ENABLED` env var (default `true`). When `false`, `AiService.streamRecommendations()` throws immediately, triggering the API's existing offline fuzzy-matching fallback — no calls to the AI container.
- Use when the model is unavailable, to save GPU, or during incidents.

### 2. `CUDA_VISIBLE_DEVICES` GPU/CPU switch
- The CUDA-built `llama-cpp-python` force-enumerates the GPU on every load and `ggml_abort()`s (exit 139) if the CUDA context can't fit — which crash-loops on small/shared GPUs (e.g. 4GB GTX 1650). `n_gpu_layers=0` does NOT avoid this; the CUDA backend initializes unconditionally.
- Defaults to GPU 0. When the GPU is busy, set `CUDA_VISIBLE_DEVICES=` (empty) to enumerate zero devices and load on CPU cleanly (verified: 2.2GB 4B model loads in ~8s). The GPU reservation stays so `libcuda.so.1` remains linkable.

### 3. n_ctx / flash-attention / quantized KV cache
- Exposes `N_CTX`, `FLASH_ATTN`, `KV_CACHE_TYPE_K`, `KV_CACHE_TYPE_V`.
- Defaults: `n_ctx=2048`, `flash_attn=true`, KV cache `q8_0/q8_0` — halves KV cache vs f16 at <0.1% quality cost (flash attention required to quantize the V cache). For tight VRAM, set `KV_CACHE_TYPE_K=q4_0`.
- Verified: loads with flash-attn + q8_0 KV and returns correct output.

## Test plan
- [ ] `AI_ENABLED=false` → `/ai/recommend?q=headache` returns fuzzy fallback, no AI calls
- [ ] `CUDA_VISIBLE_DEVICES=` → AI service loads on CPU without crash loop
- [ ] Default config → GPU load once the card is free