### PR TITLE
fix(docker): stop web prod container reinstalling deps on every boot

### DIFF
--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -1,6 +1,6 @@
 FROM node:22-alpine AS builder
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@11.3.0 --activate
 ENV PNPM_CONFIG_TRUST_LOCKFILE=true
 
 WORKDIR /app
@@ -28,8 +28,12 @@ RUN pnpm build
 
 FROM node:22-alpine AS runner
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@11.3.0 --activate
 ENV PNPM_CONFIG_TRUST_LOCKFILE=true
+# Prevent pnpm from re-verifying/installing deps at container start. The image is
+# built with `--prod`, which pnpm's verify-deps-before-run otherwise treats as
+# out-of-sync and "fixes" by running a full network install on every boot.
+ENV PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false
 ENV NODE_ENV=production
 
 WORKDIR /app
@@ -47,4 +51,7 @@ COPY packages/types ./packages/types
 WORKDIR /app/apps/web
 
 EXPOSE 3000
-CMD ["pnpm", "start"]
+# Invoke the Next.js binary directly rather than via `pnpm start`, so no pnpm
+# dependency verification/install runs at container startup (avoids boot-time
+# network calls to the npm registry).
+CMD ["/app/apps/web/node_modules/.bin/next", "start", "--port", "3000"]


### PR DESCRIPTION
## Problem

The production site returned **502** because the `web` container ran a full `pnpm install` over the network at every startup *before* launching Next.js. When npmjs.org was intermittently unreachable, the install stalled retrying `@clerk/shared` (`error 23`), delaying boot ~3.5 min — Nginx returned 502 the whole time.

### Root cause
The image bakes deps with `pnpm install --frozen-lockfile --prod` and `CMD pnpm start`. But:
- `corepack prepare pnpm@latest` mismatched the pinned `packageManager: pnpm@11.3.0`.
- pnpm 11's `verify-deps-before-run` treats the `--prod` node_modules as out-of-sync when running a script, so `pnpm start` triggered a **full** install (pulling dev deps like `eslint`/`vite`) over the network on every boot.

Confirmed in container logs: dev deps being installed at runtime + registry connection failures.

## Fix
- Pin pnpm to `11.3.0` in both stages (matches `packageManager`).
- Set `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false` in the runner stage.
- Launch the `next` binary directly instead of via `pnpm start`, bypassing pnpm's dep verification/install at startup.

Net effect: the web container no longer touches the npm registry at startup, so a flaky registry can't cause a 502 on restart.

## Test plan
- [ ] `docker compose -f docker-compose.prod.yml build web` succeeds
- [ ] Container starts and serves on :3000 with **no** `pnpm install` / registry traffic in logs
- [ ] Site returns 200 after a fresh deploy