### PR TITLE
fix(web): doctor profile page crash (React error #438)

### DIFF
--- a/apps/web/src/app/doctors/[id]/page.tsx
+++ b/apps/web/src/app/doctors/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useEffect, use } from 'react'
-import { useRouter } from 'next/navigation'
+import { useState, useEffect } from 'react'
+import { useRouter, useParams } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
 import { User, Calendar, Clock, ArrowLeft } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
@@ -30,8 +30,8 @@ function groupByDate(slots: Slot[]): Record<string, Slot[]> {
   }, {} as Record<string, Slot[]>)
 }
 
-export default function DoctorDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = use(params)
+export default function DoctorDetailPage() {
+  const { id } = useParams<{ id: string }>()
   const router = useRouter()
   const { getToken, isSignedIn } = useAuth()
 


### PR DESCRIPTION
Switches the doctor profile page from `use(params)` to `useParams()`.

`use(params)` treated `params` as a Promise (Next 15 API), but the app is on Next 14 where `params` is a plain object — React 18's `use()` rejects it with error #438, crashing the page on click. `useParams()` matches the sibling dynamic routes.

Fixes #63