### PR TITLE
fix(web): consistent navbar — show profile when logged in

### DIFF
--- a/apps/web/src/app/doctors/[id]/page.tsx
+++ b/apps/web/src/app/doctors/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter, useParams } from 'next/navigation'
-import { useAuth } from '@clerk/nextjs'
+import { useAuth, Show, UserButton } from '@clerk/nextjs'
 import { User, Calendar, Clock, ArrowLeft } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 
@@ -110,6 +110,16 @@ export default function DoctorDetailPage() {
           <ArrowLeft size={16} /> Back
         </button>
         <span style={{ fontSize: '18px', fontWeight: 700, color: '#111827', letterSpacing: '-0.5px' }}>LunaSol</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: '16px', alignItems: 'center' }}>
+          <Show when="signed-out">
+            <a href="/sign-in" style={{ padding: '8px 16px', border: '1px solid #cbd5e1', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#475569', textDecoration: 'none' }}>Sign In</a>
+            <a href="/sign-up" style={{ padding: '8px 16px', background: '#0f172a', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#ffffff', textDecoration: 'none' }}>Sign Up</a>
+          </Show>
+          <Show when="signed-in">
+            <a href="/dashboard" style={{ fontSize: '14px', fontWeight: 600, color: '#111827', textDecoration: 'none' }}>Dashboard</a>
+            <UserButton />
+          </Show>
+        </div>
       </nav>
 
       <main style={{ maxWidth: '900px', margin: '0 auto', padding: '40px 24px', display: 'grid', gridTemplateColumns: '1fr 360px', gap: '32px', alignItems: 'start' }}>

--- a/apps/web/src/app/doctors/page.tsx
+++ b/apps/web/src/app/doctors/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, FormEvent, useRef } from 'react'
 import { useRouter } from 'next/navigation'
+import { Show, UserButton } from '@clerk/nextjs'
 import { Search, Filter, User, Sparkles, AlertTriangle, Send, RefreshCw, X, ArrowRight, ShieldCheck, HeartPulse } from 'lucide-react'
 import { useAiRecommendation, ChatMessage } from '../../lib/useAiRecommendation'
 import { SPECIALIZATIONS as SPECIALIZATION_OPTIONS } from '@lunasol/types'
@@ -308,9 +309,15 @@ export default function DoctorsPage() {
           <HeartPulse size={24} color="#6366f1" />
           <span>LunaSol</span>
         </a>
-        <div style={{ display: 'flex', gap: '16px' }}>
-          <a href="/sign-in" style={{ padding: '8px 16px', border: '1px solid #cbd5e1', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#475569', textDecoration: 'none', transition: 'background-color 0.2s' }}>Sign In</a>
-          <a href="/sign-up" style={{ padding: '8px 16px', background: '#0f172a', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#ffffff', textDecoration: 'none', transition: 'background-color 0.2s' }}>Sign Up</a>
+        <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
+          <Show when="signed-out">
+            <a href="/sign-in" style={{ padding: '8px 16px', border: '1px solid #cbd5e1', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#475569', textDecoration: 'none', transition: 'background-color 0.2s' }}>Sign In</a>
+            <a href="/sign-up" style={{ padding: '8px 16px', background: '#0f172a', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#ffffff', textDecoration: 'none', transition: 'background-color 0.2s' }}>Sign Up</a>
+          </Show>
+          <Show when="signed-in">
+            <a href="/dashboard" style={{ padding: '8px 16px', fontSize: '14px', fontWeight: 600, color: '#0f172a', textDecoration: 'none' }}>Dashboard</a>
+            <UserButton />
+          </Show>
         </div>
       </nav>
 


### PR DESCRIPTION
## Problem

The navbar was inconsistent across pages. On the doctor-facing public pages, the nav showed **Sign In / Sign Up** buttons even when the user was already logged in:

- `/doctors` (doctor selection) hardcoded Sign In / Sign Up links regardless of auth state.
- `/doctors/[id]` (doctor profile) had no auth/profile controls at all.

The landing page already did the right thing (Clerk `<Show>` → `UserButton` when signed in).

## Fix

Gate the nav controls with Clerk `<Show>` on both pages, matching the landing page:
- **Signed out:** Sign In / Sign Up
- **Signed in:** Dashboard link + `<UserButton />`

## Notes

Dashboard pages already render `UserButton` and are behind auth, so they were unaffected. This brings the public pages in line.