### PR TITLE
feat(web): live time-remaining countdown on upcoming appointment cards

### DIFF
--- a/apps/web/src/app/dashboard/doctor/appointments/page.tsx
+++ b/apps/web/src/app/dashboard/doctor/appointments/page.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
-import { Calendar, Clock, User } from 'lucide-react'
+import { Calendar, Clock, User, Hourglass } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
+import { formatTimeRemaining, useNow } from '@/lib/time'
 
 interface Appointment {
   id: string
@@ -94,6 +95,9 @@ export default function DoctorAppointmentsPage() {
 function AppointmentCard({ appt, onClick }: { appt: Appointment; onClick: () => void }) {
   const statusStyle = STATUS_COLORS[appt.status] || { bg: '#f3f4f6', text: '#374151' }
   const date = new Date(appt.slot.startTime)
+  const isUpcoming = appt.status === 'PENDING' || appt.status === 'CONFIRMED'
+  const now = useNow()
+  const timeRemaining = isUpcoming ? formatTimeRemaining(appt.slot.startTime, now) : null
 
   return (
     <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '20px 24px', cursor: 'pointer' }} onClick={onClick}>
@@ -116,6 +120,11 @@ function AppointmentCard({ appt, onClick }: { appt: Appointment; onClick: () => 
         <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
           <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
         </span>
+        {timeRemaining && (
+          <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+            <Hourglass size={14} /> {timeRemaining}
+          </span>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/app/dashboard/patient/appointments/page.tsx
+++ b/apps/web/src/app/dashboard/patient/appointments/page.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
-import { Calendar, Clock } from 'lucide-react'
+import { Calendar, Clock, Hourglass } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
+import { formatTimeRemaining, useNow } from '@/lib/time'
 
 interface Appointment {
   id: string
@@ -117,6 +118,8 @@ function AppointmentCard({ appt, onCancel, cancelling, onClick }: {
   const statusStyle = STATUS_COLORS[appt.status] || { bg: '#f3f4f6', text: '#374151' }
   const date = new Date(appt.slot.startTime)
   const canCancel = appt.status === 'PENDING' || appt.status === 'CONFIRMED'
+  const now = useNow()
+  const timeRemaining = canCancel ? formatTimeRemaining(appt.slot.startTime, now) : null
 
   return (
     <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '20px 24px', cursor: 'pointer' }} onClick={onClick}>
@@ -137,6 +140,11 @@ function AppointmentCard({ appt, onCancel, cancelling, onClick }: {
         <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
           <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
         </span>
+        {timeRemaining && (
+          <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+            <Hourglass size={14} /> {timeRemaining}
+          </span>
+        )}
       </div>
 
       {canCancel && (

--- a/apps/web/src/lib/time.ts
+++ b/apps/web/src/lib/time.ts
@@ -1,0 +1,57 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * Format the time remaining until an appointment's absolute UTC start instant.
+ *
+ * Pure and timezone-agnostic: it compares two absolute instants (epoch ms), so
+ * it stays consistent with browser-local `toLocaleTimeString` rendering — both
+ * derive from the same underlying UTC instant.
+ *
+ * @param startTimeIso ISO 8601 timestamp of the appointment start.
+ * @param now Epoch ms to compare against; defaults to `Date.now()`.
+ * @returns A short human label, or `null` when there's nothing to show.
+ *   - `null` when the start time is invalid or already past (more than a moment ago)
+ *   - `"starting now"` when within the start instant (<= 0)
+ *   - `"in 45m"` when under an hour away
+ *   - `"in 2h 15m"` when under a day away
+ *   - `"in 3d 4h"` when a day or more away
+ */
+export function formatTimeRemaining(startTimeIso: string, now?: number): string | null {
+  const start = new Date(startTimeIso).getTime()
+  if (Number.isNaN(start)) return null
+
+  const diffMs = start - (now ?? Date.now())
+
+  if (diffMs <= 0) {
+    // Within a short grace window of the start, surface "starting now".
+    // Past that, the appointment is effectively underway/over — hide it.
+    return diffMs > -60_000 ? 'starting now' : null
+  }
+
+  const totalMinutes = Math.floor(diffMs / 60_000)
+  const minutes = totalMinutes % 60
+  const totalHours = Math.floor(totalMinutes / 60)
+  const hours = totalHours % 24
+  const days = Math.floor(totalHours / 24)
+
+  if (days >= 1) return `in ${days}d ${hours}h`
+  if (totalHours >= 1) return `in ${totalHours}h ${minutes}m`
+  return `in ${totalMinutes}m`
+}
+
+/**
+ * Returns a `Date.now()` value that ticks every `intervalMs` (default 1 minute),
+ * so countdowns on a long-open page don't go stale. Cleans up on unmount.
+ */
+export function useNow(intervalMs = 60_000): number {
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs)
+    return () => clearInterval(id)
+  }, [intervalMs])
+
+  return now
+}


### PR DESCRIPTION
Closes #65

## Summary
Adds a live "time remaining" countdown to upcoming appointment cards on both the patient and doctor appointments pages, with timezone-correct computation.

- New shared helper `apps/web/src/lib/time.ts`:
  - `formatTimeRemaining(startTimeIso, now?)` — pure, timezone-agnostic. Compares absolute UTC instants (`new Date(iso).getTime() - now`). Returns `null` (past/invalid), `"starting now"` (<=0 within a 60s grace), `"in 45m"` (<1h), `"in 2h 15m"` (<24h), or `"in 3d 4h"` (>=24h).
  - `useNow(intervalMs = 60000)` client hook — returns a `Date.now()` value that ticks every minute and cleans up on unmount, so countdowns don't go stale on a long-open page.
- Patient and doctor `AppointmentCard`s render the countdown (Hourglass icon, matching muted 13px / #6b7280 style) next to the existing Calendar/Clock line, only for upcoming appointments (PENDING/CONFIRMED with a future start). When the helper returns `null`, nothing renders.

The countdown derives from the same absolute UTC instant as the existing `toLocaleTimeString` label, so there's no off-by-TZ disagreement.

## How to verify
1. `pnpm --filter @lunasol/types build && pnpm --filter @lunasol/web build` — passes with no type/lint errors.
2. As a patient/doctor with upcoming appointments, open the appointments page: each upcoming card shows e.g. "in 2h 15m" next to the time; it updates each minute. Past/cancelled/completed cards show no countdown.