### PR TITLE
fix(web): UX cleanup of the AI doctor matcher on /doctors

### DIFF
--- a/apps/web/src/app/doctors/page.tsx
+++ b/apps/web/src/app/doctors/page.tsx
@@ -443,8 +443,26 @@ export default function DoctorsPage() {
             )}
           </div>
 
-          {/* 2. Symptom Input Area & Conversational Flow */}
-          {messages.length === 0 ? (
+          {/* 2. Symptom Input Area & Conversational Flow.
+                When the AI service is unavailable, hide both the form and the
+                chat and point users to the directory below as a fallback. */}
+          {aiError ? (
+            <div style={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: '12px',
+              background: '#f8fafc',
+              border: '1px solid #e2e8f0',
+              borderRadius: '16px',
+              padding: '16px 20px',
+              color: '#475569',
+              fontSize: '14px',
+              lineHeight: '1.5'
+            }}>
+              <Info size={18} color="#94a3b8" style={{ flexShrink: 0, marginTop: '1px' }} />
+              <span>Smart matching is temporarily unavailable — browse the directory below.</span>
+            </div>
+          ) : messages.length === 0 ? (
             <form onSubmit={handleAiSubmit}>
               <div style={{ position: 'relative', marginBottom: '16px' }}>
                 <textarea

--- a/apps/web/src/app/doctors/page.tsx
+++ b/apps/web/src/app/doctors/page.tsx
@@ -339,9 +339,9 @@ export default function DoctorsPage() {
             <div>
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px' }}>
                 <Sparkles size={20} color="#6366f1" style={{ filter: 'drop-shadow(0 0 6px rgba(99, 102, 241, 0.4))' }} />
-                <h2 style={{ fontSize: '22px', fontWeight: 800, color: '#0f172a', margin: 0, letterSpacing: '-0.5px' }}>AI-Powered Doctor Matcher</h2>
+                <h2 style={{ fontSize: '22px', fontWeight: 800, color: '#0f172a', margin: 0, letterSpacing: '-0.5px' }}>Find the right specialist</h2>
               </div>
-              <p style={{ fontSize: '14px', color: '#475569', margin: 0 }}>Describe your symptoms, and MedGemma AI will recommend the most appropriate specialists.</p>
+              <p style={{ fontSize: '14px', color: '#475569', margin: 0 }}>Describe your symptoms and we&apos;ll suggest the right specialties.</p>
             </div>
             
             {(messages.length > 0 || reasoning || recommendedDoctors.length > 0 || aiLoading) && (
@@ -496,7 +496,7 @@ export default function DoctorsPage() {
                   ) : (
                     <>
                       <Send size={15} />
-                      <span>Find My Doctor Match</span>
+                      <span>Find a specialist</span>
                     </>
                   )}
                 </button>
@@ -523,7 +523,7 @@ export default function DoctorsPage() {
                 <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px', borderBottom: '1px solid #e2e8f0', paddingBottom: '10px' }}>
                   <div style={{ width: '8px', height: '8px', borderRadius: '50%', background: aiLoading ? '#22c55e' : '#64748b', animation: aiLoading ? 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite' : 'none' }} />
                   <span style={{ fontSize: '12px', fontWeight: 700, color: '#475569', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
-                    {aiLoading ? 'MedGemma 1.5 Chat Active' : 'MedGemma Triage Session'}
+                    {aiLoading ? 'Matching in progress' : 'Symptom assistant'}
                   </span>
                 </div>
 
@@ -578,7 +578,7 @@ export default function DoctorsPage() {
                           color: '#64748b',
                           alignSelf: isUser ? 'flex-end' : 'flex-start'
                         }}>
-                          {isUser ? 'You (Patient)' : 'MedGemma AI'}
+                          {isUser ? 'You' : 'Symptom assistant'}
                         </span>
 
                         {bubbleIsEmergency && (
@@ -635,7 +635,7 @@ export default function DoctorsPage() {
                   type="text"
                   value={followUpQuery}
                   onChange={(e) => setFollowUpQuery(e.target.value)}
-                  placeholder="Reply to MedGemma or provide more details..."
+                  placeholder="Reply or provide more details..."
                   disabled={aiLoading}
                   style={{
                     flex: 1,
@@ -691,7 +691,7 @@ export default function DoctorsPage() {
             <div style={{ marginTop: '36px' }}>
               <h3 style={{ fontSize: '16px', fontWeight: 800, color: '#0f172a', marginBottom: '20px', display: 'flex', alignItems: 'center', gap: '8px' }}>
                 <Sparkles size={16} color="#8b5cf6" />
-                <span>AI Recommended Specialist Matching ({recommendedDoctors.length})</span>
+                <span>Suggested specialists ({recommendedDoctors.length})</span>
                 {aiError && <span style={{ fontSize: '12px', color: '#ef4444', fontWeight: 500 }}>({aiError})</span>}
               </h3>
               
@@ -776,7 +776,7 @@ export default function DoctorsPage() {
                       }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: '4px', fontWeight: 700, marginBottom: '4px', fontSize: '12px' }}>
                           <Sparkles size={12} color="#7c3aed" />
-                          <span>AI MATCH RATIONALE</span>
+                          <span>WHY THIS MATCH</span>
                         </div>
                         {doc.reason}
                       </div>

--- a/apps/web/src/app/doctors/page.tsx
+++ b/apps/web/src/app/doctors/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, FormEvent, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { Show, UserButton } from '@clerk/nextjs'
-import { Search, Filter, User, Sparkles, AlertTriangle, Send, RefreshCw, X, ArrowRight, ShieldCheck, HeartPulse } from 'lucide-react'
+import { Search, Filter, User, Sparkles, AlertTriangle, Send, RefreshCw, X, ArrowRight, ShieldCheck, HeartPulse, Info } from 'lucide-react'
 import { useAiRecommendation, ChatMessage } from '../../lib/useAiRecommendation'
 import { SPECIALIZATIONS as SPECIALIZATION_OPTIONS } from '@lunasol/types'
 
@@ -186,6 +186,78 @@ const formatAiResponse = (content: string, isUser: boolean = false) => {
   return <div style={{ display: 'flex', flexDirection: 'column' }}>{elements}</div>
 }
 
+// Compact, accessible disclaimer indicator. Reveals the full safety/legal text
+// on hover and on keyboard focus. The text stays in the DOM (role="tooltip")
+// and is associated with the trigger via aria-describedby for screen readers.
+function DisclaimerTooltip() {
+  const [open, setOpen] = useState(false)
+  const tooltipId = 'ai-matcher-disclaimer'
+
+  return (
+    <div
+      style={{ position: 'relative', display: 'inline-flex' }}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+    >
+      <button
+        type="button"
+        aria-describedby={tooltipId}
+        aria-expanded={open}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '6px',
+          padding: '5px 10px',
+          borderRadius: '8px',
+          border: '1px solid rgba(245, 158, 11, 0.3)',
+          background: 'rgba(254, 243, 199, 0.55)',
+          color: '#92400e',
+          fontSize: '12.5px',
+          fontWeight: 600,
+          cursor: 'help',
+        }}
+      >
+        <ShieldCheck size={14} color="#d97706" style={{ flexShrink: 0 }} />
+        <span>Informational only</span>
+        <Info size={13} color="#d97706" style={{ flexShrink: 0 }} />
+      </button>
+
+      <div
+        id={tooltipId}
+        role="tooltip"
+        style={{
+          position: 'absolute',
+          top: 'calc(100% + 8px)',
+          right: 0,
+          zIndex: 20,
+          width: '320px',
+          maxWidth: '80vw',
+          background: 'rgba(254, 243, 199, 0.97)',
+          border: '1px solid rgba(245, 158, 11, 0.4)',
+          borderRadius: '12px',
+          padding: '14px 16px',
+          color: '#92400e',
+          fontSize: '13px',
+          lineHeight: '1.5',
+          boxShadow: '0 12px 28px -10px rgba(146, 64, 14, 0.25)',
+          opacity: open ? 1 : 0,
+          visibility: open ? 'visible' : 'hidden',
+          transform: open ? 'translateY(0)' : 'translateY(-4px)',
+          transition: 'opacity 0.15s ease, transform 0.15s ease',
+          pointerEvents: open ? 'auto' : 'none',
+          textAlign: 'left',
+          fontWeight: 400,
+        }}
+      >
+        <strong style={{ fontWeight: 700, display: 'block', marginBottom: '4px', fontSize: '13.5px' }}>AI Triage Advisor (Informational Only)</strong>
+        This tool utilizes clinical-grade language models to map described symptoms to specialties within our network. It <strong>does not diagnose illnesses, prescribe medications, or replace professional medical advice</strong>. If you are experiencing a severe, sudden, or life-threatening situation, please call emergency responders (e.g. 911) immediately.
+      </div>
+    </div>
+  )
+}
+
 export default function DoctorsPage() {
   const router = useRouter()
   const [doctors, setDoctors] = useState<Doctor[]>([])
@@ -340,6 +412,7 @@ export default function DoctorsPage() {
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px' }}>
                 <Sparkles size={20} color="#6366f1" style={{ filter: 'drop-shadow(0 0 6px rgba(99, 102, 241, 0.4))' }} />
                 <h2 style={{ fontSize: '22px', fontWeight: 800, color: '#0f172a', margin: 0, letterSpacing: '-0.5px' }}>Find the right specialist</h2>
+                <DisclaimerTooltip />
               </div>
               <p style={{ fontSize: '14px', color: '#475569', margin: 0 }}>Describe your symptoms and we&apos;ll suggest the right specialties.</p>
             </div>
@@ -368,27 +441,6 @@ export default function DoctorsPage() {
                 <span>Clear Analysis</span>
               </button>
             )}
-          </div>
-
-          {/* 1. Amber Disclaimer Banner (Required Guardrail) */}
-          <div style={{
-            background: 'rgba(254, 243, 199, 0.55)',
-            border: '1px solid rgba(245, 158, 11, 0.3)',
-            backdropFilter: 'blur(8px)',
-            borderRadius: '16px',
-            padding: '16px 20px',
-            display: 'flex',
-            gap: '14px',
-            color: '#92400e',
-            fontSize: '13.5px',
-            lineHeight: '1.5',
-            marginBottom: '24px'
-          }}>
-            <ShieldCheck size={20} color="#d97706" style={{ flexShrink: 0, marginTop: '2px' }} />
-            <div>
-              <strong style={{ fontWeight: 700, display: 'block', marginBottom: '2px', fontSize: '14px' }}>AI Triage Advisor (Informational Only)</strong>
-              This tool utilizes clinical-grade language models to map described symptoms to specialties within our network. It <strong>does not diagnose illnesses, prescribe medications, or replace professional medical advice</strong>. If you are experiencing a severe, sudden, or life-threatening situation, please call emergency responders (e.g. 911) immediately.
-            </div>
           </div>
 
           {/* 2. Symptom Input Area & Conversational Flow */}


### PR DESCRIPTION
Closes #68

## Summary
UX cleanup of the AI doctor matcher on `/doctors`:

1. **De-buzzworded the copy** — replaced hype/branded wording with plain, honest language:
   - Heading: "AI-Powered Doctor Matcher" → "Find the right specialist"
   - Subhead: "...MedGemma AI will recommend..." → "Describe your symptoms and we'll suggest the right specialties."
   - Submit button: "Find My Doctor Match" → "Find a specialist"
   - Chat status: "MedGemma 1.5 Chat Active" / "MedGemma Triage Session" → "Matching in progress" / "Symptom assistant"
   - Sender label "MedGemma AI" → "Symptom assistant"; follow-up placeholder de-branded
   - Section heading "AI Recommended Specialist Matching" → "Suggested specialists"; "AI MATCH RATIONALE" → "WHY THIS MATCH"

2. **Collapsed the always-on orange disclaimer into an accessible tooltip** — a compact "Informational only" indicator (ShieldCheck + Info icons) sits next to the matcher heading and reveals the full, unchanged legal/safety text on hover **and** keyboard focus. Built as a small custom inline-styled `DisclaimerTooltip` (no new dependency). The trigger is a focusable `<button>` with `aria-describedby`, and the popover has `role="tooltip"` and a matching `id`, so the wording stays in the DOM and is screen-reader friendly.

3. **Hide the conversation UI when the AI service is down** — uses the `error` state from `useAiRecommendation`. When the AI is unavailable, neither the symptom form nor the chat renders; instead a small inline note "Smart matching is temporarily unavailable — browse the directory below." is shown. If an error occurs mid-conversation it collapses back to this note. The "Browse Medical Directory" search + filters section always renders as the graceful fallback.

## How to verify
- Load `/doctors`: heading reads "Find the right specialist", the orange banner is gone, and an "Informational only" chip sits beside the heading. Hover **or** tab to it to reveal the full disclaimer text.
- Submit symptoms and confirm the chat status/labels use neutral wording.
- Simulate the AI being down (stop the `ai` service, or make `/api/ai/recommend` fail/time out so the EventSource errors): the form/chat disappears and the "temporarily unavailable" note appears, while the directory below remains usable.

Verified with `pnpm --filter @lunasol/web build` (passes; `@lunasol/types` built first).