### PR TITLE
feat: instant (on-demand) appointments

### DIFF
--- a/apps/api/prisma/migrations/20260530120000_instant_appointments/migration.sql
+++ b/apps/api/prisma/migrations/20260530120000_instant_appointments/migration.sql
@@ -1,0 +1,10 @@
+-- Instant (on-demand) appointments.
+-- Doctors opt in via `acceptingInstant`; instant appointments have no pre-booked
+-- slot, so `slotId` becomes nullable and `isInstant` flags the on-demand flow.
+
+-- DoctorProfile: opt-in presence toggle.
+ALTER TABLE "DoctorProfile" ADD COLUMN "acceptingInstant" BOOLEAN NOT NULL DEFAULT false;
+
+-- Appointment: slot is now optional; add the instant flag.
+ALTER TABLE "Appointment" ADD COLUMN "isInstant" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Appointment" ALTER COLUMN "slotId" DROP NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -60,6 +60,7 @@ model DoctorProfile {
   specialization    String
   profilePictureUrl String?
   contactDetails    String?
+  acceptingInstant  Boolean            @default(false)
   slots             AvailabilitySlot[]
   appointments      Appointment[]
 }
@@ -84,8 +85,9 @@ model Appointment {
   patient   PatientProfile     @relation(fields: [patientId], references: [id])
   doctorId  String
   doctor    DoctorProfile      @relation(fields: [doctorId], references: [id])
-  slotId    String             @unique
-  slot      AvailabilitySlot   @relation(fields: [slotId], references: [id])
+  slotId    String?            @unique
+  slot      AvailabilitySlot?  @relation(fields: [slotId], references: [id])
+  isInstant Boolean            @default(false)
   status      AppointmentStatus  @default(PENDING)
   livekitRoom String?
   createdAt DateTime           @default(now())

--- a/apps/api/src/appointments/appointments.controller.ts
+++ b/apps/api/src/appointments/appointments.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, Get, Patch, Param, Body, Req, Query } from '@nestjs/c
 import { Roles } from '../auth/decorators/roles.decorator'
 import { AppointmentsService } from './appointments.service'
 import { BookAppointmentDto } from './dto/book-appointment.dto'
+import { InstantAppointmentDto } from './dto/instant-appointment.dto'
 import { RescheduleAppointmentDto } from './dto/reschedule-appointment.dto'
 
 @Controller('appointments')
@@ -12,6 +13,12 @@ export class AppointmentsController {
   @Post()
   book(@Req() req: any, @Body() dto: BookAppointmentDto) {
     return this.appointmentsService.book(req.user.id, dto)
+  }
+
+  @Roles('patient')
+  @Post('instant')
+  createInstant(@Req() req: any, @Body() dto: InstantAppointmentDto) {
+    return this.appointmentsService.createInstant(req.user.id, dto)
   }
 
   @Roles('patient', 'doctor')

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -10,6 +10,7 @@ import { AccessToken, WebhookReceiver } from 'livekit-server-sdk'
 import { PrismaService } from '../prisma/prisma.service'
 import { NotificationsService } from '../notifications/notifications.service'
 import { BookAppointmentDto } from './dto/book-appointment.dto'
+import { InstantAppointmentDto } from './dto/instant-appointment.dto'
 import { RescheduleAppointmentDto } from './dto/reschedule-appointment.dto'
 import { AppointmentStatus } from '@prisma/client'
 
@@ -102,13 +103,46 @@ export class AppointmentsService {
     }
   }
 
+  async createInstant(clerkId: string, dto: InstantAppointmentDto) {
+    const { patient } = await this.getPatientProfile(clerkId)
+
+    const doctor = await this.prisma.doctorProfile.findUnique({
+      where: { id: dto.doctorId },
+      include: { user: true },
+    })
+    if (!doctor) throw new NotFoundException('Doctor not found')
+    if (!doctor.acceptingInstant) {
+      throw new ConflictException('This doctor is not accepting instant consultations right now')
+    }
+
+    const appointment = await this.prisma.appointment.create({
+      data: {
+        patientId: patient.id,
+        doctorId: doctor.id,
+        slotId: null,
+        isInstant: true,
+        status: AppointmentStatus.PENDING,
+      },
+      include: { slot: true, doctor: true, patient: true },
+    })
+
+    await this.createNotification(
+      doctor.user.id,
+      'APPOINTMENT_REQUEST',
+      `${patient.name} is requesting an instant consultation now`,
+    )
+
+    return appointment
+  }
+
   async listMine(clerkId: string, role: string, patientId?: string) {
     if (role === 'doctor') {
       const { doctor } = await this.getDoctorProfile(clerkId)
       return this.prisma.appointment.findMany({
         where: { doctorId: doctor.id, ...(patientId ? { patientId } : {}) },
         include: { slot: true, patient: true, record: { include: { prescriptions: true } } },
-        orderBy: { slot: { startTime: 'asc' } },
+        // slot may be null for instant appointments; fall back to creation order.
+        orderBy: [{ slot: { startTime: 'asc' } }, { createdAt: 'asc' }],
       })
     }
 
@@ -116,7 +150,8 @@ export class AppointmentsService {
     return this.prisma.appointment.findMany({
       where: { patientId: patient.id },
       include: { slot: true, doctor: true, record: { include: { prescriptions: true } } },
-      orderBy: { slot: { startTime: 'asc' } },
+      // slot may be null for instant appointments; fall back to creation order.
+      orderBy: [{ slot: { startTime: 'asc' } }, { createdAt: 'asc' }],
     })
   }
 
@@ -146,7 +181,9 @@ export class AppointmentsService {
     await this.createNotification(
       appointment.doctor.user.id,
       'APPOINTMENT_CANCELLED',
-      `${patient.name} cancelled their appointment on ${appointment.slot.startTime.toLocaleDateString()}`,
+      appointment.isInstant || !appointment.slot
+        ? `${patient.name} cancelled their instant consultation request`
+        : `${patient.name} cancelled their appointment on ${appointment.slot.startTime.toLocaleDateString()}`,
     )
 
     return updated
@@ -235,7 +272,9 @@ export class AppointmentsService {
     await this.createNotification(
       appointment.patient.user.id,
       'APPOINTMENT_CONFIRMED',
-      `Your appointment on ${appointment.slot.startTime.toLocaleDateString()} has been confirmed. Join the session when it's time.`,
+      appointment.isInstant || !appointment.slot
+        ? `Your instant consultation has been confirmed. Join the session now.`
+        : `Your appointment on ${appointment.slot.startTime.toLocaleDateString()} has been confirmed. Join the session when it's time.`,
     )
 
     return updated
@@ -308,15 +347,19 @@ export class AppointmentsService {
       throw new ConflictException('Session not available')
     }
 
-    // Enforce the join window server-side. The client gates the "Join" button on
-    // the same window, but the token endpoint must not be joinable out-of-band.
-    const now = Date.now()
-    const start = appointment.slot.startTime.getTime()
-    const end = appointment.slot.endTime.getTime()
-    if (now < start - JOIN_LEAD_MS || now > end) {
-      throw new ForbiddenException(
-        'The consultation room is only open from 5 minutes before the appointment until it ends',
-      )
+    // Enforce the join window server-side for scheduled appointments. The client
+    // gates the "Join" button on the same window, but the token endpoint must not
+    // be joinable out-of-band. Instant appointments have no slot, so the room is
+    // open immediately while the appointment is CONFIRMED.
+    if (!appointment.isInstant && appointment.slot) {
+      const now = Date.now()
+      const start = appointment.slot.startTime.getTime()
+      const end = appointment.slot.endTime.getTime()
+      if (now < start - JOIN_LEAD_MS || now > end) {
+        throw new ForbiddenException(
+          'The consultation room is only open from 5 minutes before the appointment until it ends',
+        )
+      }
     }
 
     const apiKey = process.env.LIVEKIT_API_KEY

--- a/apps/api/src/appointments/dto/instant-appointment.dto.ts
+++ b/apps/api/src/appointments/dto/instant-appointment.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator'
+
+export class InstantAppointmentDto {
+  @IsString()
+  @IsNotEmpty()
+  doctorId!: string
+}

--- a/apps/api/src/doctors/doctors.controller.ts
+++ b/apps/api/src/doctors/doctors.controller.ts
@@ -21,6 +21,7 @@ import { Roles } from '../auth/decorators/roles.decorator'
 import { Public } from '../auth/decorators/public.decorator'
 import { DoctorsService } from './doctors.service'
 import { UpdateDoctorProfileDto } from './dto/update-doctor-profile.dto'
+import { UpdateInstantDto } from './dto/update-instant.dto'
 import { CreateAvailabilitySlotDto } from './dto/create-availability-slot.dto'
 
 const uploadDir = join(process.cwd(), 'uploads', 'profile-pictures')
@@ -66,6 +67,12 @@ export class DoctorsController implements OnModuleInit {
   @Patch('me')
   async updateProfile(@Req() req: any, @Body() dto: UpdateDoctorProfileDto) {
     return this.doctorsService.updateProfile(req.user.id, dto)
+  }
+
+  @Roles('doctor')
+  @Patch('me/instant')
+  async setAcceptingInstant(@Req() req: any, @Body() dto: UpdateInstantDto) {
+    return this.doctorsService.setAcceptingInstant(req.user.id, dto.acceptingInstant)
   }
 
   @Roles('doctor')

--- a/apps/api/src/doctors/doctors.service.ts
+++ b/apps/api/src/doctors/doctors.service.ts
@@ -78,6 +78,7 @@ export class DoctorsService {
         bio: true,
         profilePictureUrl: true,
         contactDetails: true,
+        acceptingInstant: true,
       },
     })
 
@@ -167,6 +168,18 @@ export class DoctorsService {
     const updated = await this.prisma.doctorProfile.update({
       where: { id: user.doctor!.id },
       data: { profilePictureUrl: `/api/uploads/profile-pictures/${filename}` },
+    })
+
+    const profileComplete = !!updated.bio && updated.bio.trim().length > 0
+    return { ...updated, profileComplete }
+  }
+
+  async setAcceptingInstant(clerkId: string, acceptingInstant: boolean) {
+    const user = await this.ensureDoctorRecord(clerkId)
+
+    const updated = await this.prisma.doctorProfile.update({
+      where: { id: user.doctor!.id },
+      data: { acceptingInstant },
     })
 
     const profileComplete = !!updated.bio && updated.bio.trim().length > 0

--- a/apps/api/src/doctors/dto/update-instant.dto.ts
+++ b/apps/api/src/doctors/dto/update-instant.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator'
+
+export class UpdateInstantDto {
+  @IsBoolean()
+  acceptingInstant!: boolean
+}

--- a/apps/web/src/app/dashboard/doctor/appointments/[id]/PatientHistory.tsx
+++ b/apps/web/src/app/dashboard/doctor/appointments/[id]/PatientHistory.tsx
@@ -16,7 +16,8 @@ interface Prescription {
 interface Appointment {
   id: string
   status: string
-  slot: { startTime: string }
+  isInstant?: boolean
+  slot: { startTime: string } | null
   record: { notes: string | null; prescriptions: Prescription[] } | null
 }
 
@@ -64,11 +65,13 @@ export default function PatientHistory({ patientId, currentAppointmentId }: { pa
           ) : (
             <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', paddingTop: '20px' }}>
               {history.map((a) => {
-                const date = new Date(a.slot.startTime)
+                const date = a.slot ? new Date(a.slot.startTime) : null
                 return (
                   <div key={a.id} style={{ background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '8px', padding: '16px' }}>
                     <p style={{ fontSize: '13px', fontWeight: 700, color: '#374151', margin: '0 0 8px' }}>
-                      {date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
+                      {date
+                        ? date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+                        : 'Instant consultation'}
                     </p>
                     {a.record?.notes ? (
                       <p style={{ fontSize: '14px', color: '#4b5563', lineHeight: 1.6, margin: '0 0 8px', whiteSpace: 'pre-line' }}>{a.record.notes}</p>

--- a/apps/web/src/app/dashboard/doctor/appointments/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/doctor/appointments/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
-import { ArrowLeft, Calendar, Clock, User, Video } from 'lucide-react'
+import { ArrowLeft, Calendar, Clock, User, Video, Zap } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import ConsultationSession from '@/components/ConsultationSession'
 import ConsultationPanel from './ConsultationPanel'
@@ -13,8 +13,9 @@ interface Appointment {
   id: string
   status: 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'COMPLETED'
   livekitRoom: string | null
+  isInstant: boolean
   patient: { id: string; name: string; profilePictureUrl: string | null }
-  slot: { startTime: string; endTime: string }
+  slot: { startTime: string; endTime: string } | null
 }
 
 const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
@@ -75,11 +76,13 @@ export default function DoctorAppointmentDetailPage() {
     return <ConsultationSession appointmentId={appt.id} onLeave={() => { setInSession(false); load() }} />
   }
 
-  const date = appt ? new Date(appt.slot.startTime) : null
+  const isInstant = !!appt?.isInstant || (!!appt && !appt.slot)
+  const date = appt?.slot ? new Date(appt.slot.startTime) : null
   const statusStyle = appt ? STATUS_COLORS[appt.status] : null
-  const start = appt ? new Date(appt.slot.startTime).getTime() : 0
-  const end = appt ? new Date(appt.slot.endTime).getTime() : 0
-  const withinWindow = now >= start - JOIN_LEAD_MS && now <= end
+  const start = appt?.slot ? new Date(appt.slot.startTime).getTime() : 0
+  const end = appt?.slot ? new Date(appt.slot.endTime).getTime() : 0
+  // Instant consultations have no slot window — joinable as soon as confirmed.
+  const withinWindow = isInstant || (now >= start - JOIN_LEAD_MS && now <= end)
   const canJoin = appt?.status === 'CONFIRMED' && !!appt.livekitRoom && withinWindow
 
   return (
@@ -123,12 +126,20 @@ export default function DoctorAppointmentDetailPage() {
               </div>
 
               <div style={{ display: 'flex', gap: '24px', paddingBottom: '24px', borderBottom: '1px solid #f3f4f6' }}>
-                <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#4b5563' }}>
-                  <Calendar size={16} color="#9ca3af" /> {date!.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}
-                </span>
-                <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#4b5563' }}>
-                  <Clock size={16} color="#9ca3af" /> {date!.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
-                </span>
+                {isInstant || !date ? (
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#059669', fontWeight: 600 }}>
+                    <Zap size={16} /> Instant consultation · Now
+                  </span>
+                ) : (
+                  <>
+                    <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#4b5563' }}>
+                      <Calendar size={16} color="#9ca3af" /> {date.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}
+                    </span>
+                    <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#4b5563' }}>
+                      <Clock size={16} color="#9ca3af" /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
+                    </span>
+                  </>
+                )}
               </div>
 
               <div style={{ display: 'flex', gap: '10px', marginTop: '24px', flexWrap: 'wrap' }}>

--- a/apps/web/src/app/dashboard/doctor/appointments/page.tsx
+++ b/apps/web/src/app/dashboard/doctor/appointments/page.tsx
@@ -3,14 +3,15 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
-import { Calendar, Clock, User } from 'lucide-react'
+import { Calendar, Clock, User, Zap } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 
 interface Appointment {
   id: string
   status: 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'COMPLETED'
+  isInstant: boolean
   patient: { id: string; name: string; profilePictureUrl: string | null }
-  slot: { startTime: string; endTime: string }
+  slot: { startTime: string; endTime: string } | null
 }
 
 const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
@@ -93,7 +94,8 @@ export default function DoctorAppointmentsPage() {
 
 function AppointmentCard({ appt, onClick }: { appt: Appointment; onClick: () => void }) {
   const statusStyle = STATUS_COLORS[appt.status] || { bg: '#f3f4f6', text: '#374151' }
-  const date = new Date(appt.slot.startTime)
+  const isInstant = appt.isInstant || !appt.slot
+  const date = appt.slot ? new Date(appt.slot.startTime) : null
 
   return (
     <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '20px 24px', cursor: 'pointer' }} onClick={onClick}>
@@ -110,12 +112,20 @@ function AppointmentCard({ appt, onClick }: { appt: Appointment; onClick: () => 
       </div>
 
       <div style={{ display: 'flex', gap: '20px' }}>
-        <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
-          <Calendar size={14} /> {date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
-        </span>
-        <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
-          <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
-        </span>
+        {isInstant || !date ? (
+          <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#059669', fontWeight: 600 }}>
+            <Zap size={14} /> Instant · Now
+          </span>
+        ) : (
+          <>
+            <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+              <Calendar size={14} /> {date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+            </span>
+            <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+              <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
+            </span>
+          </>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/app/dashboard/doctor/components/InstantToggle.tsx
+++ b/apps/web/src/app/dashboard/doctor/components/InstantToggle.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useAuth } from '@clerk/nextjs'
+import { Zap } from 'lucide-react'
+import { apiFetch } from '@/lib/api'
+
+export default function InstantToggle() {
+  const { getToken } = useAuth()
+  const [accepting, setAccepting] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        const token = await getToken()
+        const data = await apiFetch('/doctors/me', { token: token || undefined })
+        setAccepting(!!data.acceptingInstant)
+      } catch {
+        // keep default
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [getToken])
+
+  async function toggle() {
+    const next = !accepting
+    setSaving(true)
+    setError('')
+    // Optimistic update.
+    setAccepting(next)
+    try {
+      const token = await getToken()
+      await apiFetch('/doctors/me/instant', {
+        token: token || undefined,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ acceptingInstant: next }),
+      })
+    } catch (err: any) {
+      setAccepting(!next)
+      setError(err.message || 'Failed to update. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '24px', marginBottom: '32px', display: 'flex', alignItems: 'center', gap: '20px', flexWrap: 'wrap' }}>
+      <div style={{ display: 'flex', padding: '12px', background: accepting ? '#ecfdf5' : '#f3f4f6', borderRadius: '12px', color: accepting ? '#059669' : '#9ca3af' }}>
+        <Zap size={24} />
+      </div>
+      <div style={{ flex: 1, minWidth: '240px' }}>
+        <h3 style={{ fontSize: '16px', fontWeight: 600, margin: '0 0 4px', color: '#111827' }}>Instant consultations</h3>
+        <p style={{ fontSize: '14px', color: '#6b7280', margin: 0, lineHeight: 1.5 }}>
+          {accepting
+            ? 'You appear as available now. Patients can start an instant consultation request with you.'
+            : 'Turn this on to let patients start an on-demand consultation with you right now.'}
+        </p>
+        {error && <p style={{ fontSize: '13px', color: '#dc2626', margin: '8px 0 0' }}>{error}</p>}
+      </div>
+      <button
+        onClick={toggle}
+        disabled={loading || saving}
+        aria-pressed={accepting}
+        style={{
+          position: 'relative',
+          width: '52px',
+          height: '30px',
+          borderRadius: '15px',
+          border: 'none',
+          background: accepting ? '#10b981' : '#d1d5db',
+          cursor: loading || saving ? 'not-allowed' : 'pointer',
+          transition: 'background 0.15s',
+          flexShrink: 0,
+        }}
+      >
+        <span
+          style={{
+            position: 'absolute',
+            top: '3px',
+            left: accepting ? '25px' : '3px',
+            width: '24px',
+            height: '24px',
+            borderRadius: '50%',
+            background: '#ffffff',
+            transition: 'left 0.15s',
+          }}
+        />
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/app/dashboard/doctor/page.tsx
+++ b/apps/web/src/app/dashboard/doctor/page.tsx
@@ -2,6 +2,7 @@ import { UserButton } from '@clerk/nextjs'
 import { currentUser } from '@clerk/nextjs/server'
 import { Video, Users, Clock, ClipboardList } from 'lucide-react'
 import NotificationBell from '@/components/NotificationBell'
+import InstantToggle from './components/InstantToggle'
 
 export default async function DoctorDashboard() {
   const user = await currentUser()
@@ -39,6 +40,8 @@ export default async function DoctorDashboard() {
             Access and manage your patients, clinical schedule, and appointments in real-time.
           </p>
         </div>
+
+        <InstantToggle />
 
         {/* Quick Stats / Actions */}
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '24px', marginBottom: '40px' }}>

--- a/apps/web/src/app/dashboard/patient/appointments/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/patient/appointments/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
-import { Calendar, Clock, Video, ArrowLeft } from 'lucide-react'
+import { Calendar, Clock, Video, ArrowLeft, Zap } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import ConsultationSession from '@/components/ConsultationSession'
 
@@ -11,8 +11,9 @@ interface Appointment {
   id: string
   status: 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'COMPLETED'
   livekitRoom: string | null
+  isInstant: boolean
   doctor: { id: string; name: string; specialization: string }
-  slot: { startTime: string; endTime: string }
+  slot: { startTime: string; endTime: string } | null
 }
 
 const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
@@ -58,9 +59,11 @@ export default function PatientAppointmentDetail() {
     return <ConsultationSession appointmentId={appt.id} onLeave={() => setInSession(false)} />
   }
 
-  const start = appt ? new Date(appt.slot.startTime).getTime() : 0
-  const end = appt ? new Date(appt.slot.endTime).getTime() : 0
-  const withinWindow = now >= start - JOIN_LEAD_MS && now <= end
+  const isInstant = !!appt?.isInstant || !appt?.slot
+  const start = appt?.slot ? new Date(appt.slot.startTime).getTime() : 0
+  const end = appt?.slot ? new Date(appt.slot.endTime).getTime() : 0
+  // Instant consultations have no slot window — the room is open as soon as it's confirmed.
+  const withinWindow = isInstant || (now >= start - JOIN_LEAD_MS && now <= end)
   const canJoin = appt?.status === 'CONFIRMED' && !!appt.livekitRoom && withinWindow
   const statusStyle = (appt && STATUS_COLORS[appt.status]) || { bg: '#f3f4f6', text: '#374151' }
 
@@ -90,12 +93,20 @@ export default function PatientAppointmentDetail() {
             </div>
 
             <div style={{ display: 'flex', gap: '24px', marginBottom: '28px' }}>
-              <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px', color: '#374151' }}>
-                <Calendar size={16} /> {new Date(appt.slot.startTime).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}
-              </span>
-              <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px', color: '#374151' }}>
-                <Clock size={16} /> {new Date(appt.slot.startTime).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
-              </span>
+              {isInstant || !appt.slot ? (
+                <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px', color: '#059669', fontWeight: 600 }}>
+                  <Zap size={16} /> Instant consultation · Now
+                </span>
+              ) : (
+                <>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px', color: '#374151' }}>
+                    <Calendar size={16} /> {new Date(appt.slot.startTime).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}
+                  </span>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px', color: '#374151' }}>
+                    <Clock size={16} /> {new Date(appt.slot.startTime).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
+                  </span>
+                </>
+              )}
             </div>
 
             {appt.status === 'CONFIRMED' && (

--- a/apps/web/src/app/dashboard/patient/appointments/page.tsx
+++ b/apps/web/src/app/dashboard/patient/appointments/page.tsx
@@ -3,14 +3,15 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
-import { Calendar, Clock } from 'lucide-react'
+import { Calendar, Clock, Zap } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 
 interface Appointment {
   id: string
   status: 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'COMPLETED'
+  isInstant: boolean
   doctor: { id: string; name: string; specialization: string; profilePictureUrl: string | null }
-  slot: { startTime: string; endTime: string }
+  slot: { startTime: string; endTime: string } | null
 }
 
 const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
@@ -115,7 +116,8 @@ function AppointmentCard({ appt, onCancel, cancelling, onClick }: {
   onClick: () => void
 }) {
   const statusStyle = STATUS_COLORS[appt.status] || { bg: '#f3f4f6', text: '#374151' }
-  const date = new Date(appt.slot.startTime)
+  const isInstant = appt.isInstant || !appt.slot
+  const date = appt.slot ? new Date(appt.slot.startTime) : null
   const canCancel = appt.status === 'PENDING' || appt.status === 'CONFIRMED'
 
   return (
@@ -131,12 +133,20 @@ function AppointmentCard({ appt, onCancel, cancelling, onClick }: {
       </div>
 
       <div style={{ display: 'flex', gap: '20px', marginBottom: canCancel ? '16px' : '0' }}>
-        <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
-          <Calendar size={14} /> {date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
-        </span>
-        <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
-          <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
-        </span>
+        {isInstant || !date ? (
+          <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#059669', fontWeight: 600 }}>
+            <Zap size={14} /> Instant · Now
+          </span>
+        ) : (
+          <>
+            <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+              <Calendar size={14} /> {date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+            </span>
+            <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+              <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
+            </span>
+          </>
+        )}
       </div>
 
       {canCancel && (

--- a/apps/web/src/app/dashboard/patient/records/page.tsx
+++ b/apps/web/src/app/dashboard/patient/records/page.tsx
@@ -23,7 +23,8 @@ interface ConsultationRecord {
 interface Appointment {
   id: string
   status: string
-  slot: { startTime: string }
+  isInstant?: boolean
+  slot: { startTime: string } | null
   doctor: { name: string; specialization: string }
   record: ConsultationRecord | null
 }
@@ -73,7 +74,10 @@ export default function RecordsPage() {
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
             {appointments.map((appt) => {
               const isOpen = expanded === appt.id
-              const date = new Date(appt.slot.startTime)
+              const date = appt.slot ? new Date(appt.slot.startTime) : null
+              const dateLabel = date
+                ? date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+                : 'Instant consultation'
 
               return (
                 <div key={appt.id} style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', overflow: 'hidden' }}>
@@ -84,7 +88,7 @@ export default function RecordsPage() {
                     <div>
                       <p style={{ fontSize: '16px', fontWeight: 700, color: '#111827', margin: '0 0 4px' }}>{appt.doctor.name}</p>
                       <p style={{ fontSize: '13px', color: '#6b7280', margin: 0 }}>
-                        {appt.doctor.specialization} · {date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
+                        {appt.doctor.specialization} · {dateLabel}
                       </p>
                     </div>
                     {isOpen ? <ChevronUp size={18} color="#6b7280" /> : <ChevronDown size={18} color="#6b7280" />}

--- a/apps/web/src/app/doctors/[id]/page.tsx
+++ b/apps/web/src/app/doctors/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { useAuth, Show, UserButton } from '@clerk/nextjs'
-import { User, Calendar, Clock, ArrowLeft } from 'lucide-react'
+import { User, Calendar, Clock, ArrowLeft, Zap } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 
 interface Doctor {
@@ -13,6 +13,7 @@ interface Doctor {
   bio: string | null
   profilePictureUrl: string | null
   contactDetails: string | null
+  acceptingInstant?: boolean
 }
 
 interface Slot {
@@ -42,6 +43,7 @@ export default function DoctorDetailPage() {
   const [booking, setBooking] = useState(false)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState(false)
+  const [startingInstant, setStartingInstant] = useState(false)
 
   useEffect(() => {
     async function load() {
@@ -82,6 +84,29 @@ export default function DoctorDetailPage() {
       setError(err.message || 'Booking failed. Please try again.')
     } finally {
       setBooking(false)
+    }
+  }
+
+  async function handleStartInstant() {
+    if (!isSignedIn) {
+      router.push('/sign-in')
+      return
+    }
+
+    setStartingInstant(true)
+    setError('')
+    try {
+      const token = await getToken()
+      const appt = await apiFetch('/appointments/instant', {
+        token: token || undefined,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ doctorId: id }),
+      })
+      router.push(`/dashboard/patient/appointments/${appt.id}`)
+    } catch (err: any) {
+      setError(err.message || 'Could not start instant consultation. Please try again.')
+      setStartingInstant(false)
     }
   }
 
@@ -160,6 +185,39 @@ export default function DoctorDetailPage() {
 
         {/* Slot picker */}
         <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '16px', padding: '24px', position: 'sticky', top: '80px' }}>
+          {doctor.acceptingInstant && (
+            <div style={{ marginBottom: '20px', paddingBottom: '20px', borderBottom: '1px solid #f3f4f6' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
+                <Zap size={18} color="#059669" />
+                <h2 style={{ fontSize: '16px', fontWeight: 700, margin: 0 }}>Available now</h2>
+              </div>
+              <p style={{ fontSize: '13px', color: '#6b7280', margin: '0 0 14px', lineHeight: 1.5 }}>
+                This doctor is online. Start a consultation right now without booking a slot.
+              </p>
+              <button
+                onClick={handleStartInstant}
+                disabled={startingInstant}
+                style={{
+                  width: '100%',
+                  padding: '12px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: '8px',
+                  background: startingInstant ? '#a7f3d0' : '#059669',
+                  border: 'none',
+                  borderRadius: '8px',
+                  color: '#ffffff',
+                  fontSize: '14px',
+                  fontWeight: 600,
+                  cursor: startingInstant ? 'not-allowed' : 'pointer',
+                }}
+              >
+                <Zap size={16} /> {startingInstant ? 'Starting...' : !isSignedIn ? 'Sign in to start' : 'Start instant consultation'}
+              </button>
+            </div>
+          )}
+
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '20px' }}>
             <Calendar size={18} color="#111827" />
             <h2 style={{ fontSize: '16px', fontWeight: 700, margin: 0 }}>Available slots</h2>

--- a/packages/types/src/appointment.ts
+++ b/packages/types/src/appointment.ts
@@ -1,3 +1,5 @@
+import type { AvailabilitySlot } from './doctor'
+
 export const AppointmentStatus = {
   PENDING: 'PENDING',
   CONFIRMED: 'CONFIRMED',
@@ -11,7 +13,10 @@ export interface Appointment {
   id: string
   patientId: string
   doctorId: string
-  slotId: string
+  /** Null for instant (on-demand) appointments, which have no pre-booked slot. */
+  slotId?: string | null
+  slot?: AvailabilitySlot | null
+  isInstant: boolean
   status: AppointmentStatus
   livekitRoom?: string
   createdAt: string

--- a/packages/types/src/doctor.ts
+++ b/packages/types/src/doctor.ts
@@ -6,6 +6,8 @@ export interface DoctorProfile {
   specialization: string
   profilePictureUrl?: string
   contactDetails?: string
+  /** Whether the doctor is currently accepting instant (on-demand) consultations. */
+  acceptingInstant?: boolean
 }
 
 export interface AvailabilitySlot {


### PR DESCRIPTION
Closes #66

## Summary
Adds **instant (on-demand) appointments** — a lean MVP. A doctor opts in via an "accepting instant" toggle; a patient clicks "Start instant consultation" on the doctor profile; the backend creates a slotless `PENDING` Appointment and notifies the doctor; the doctor confirms (reusing the existing confirm flow, which mints the LiveKit room); both join the room immediately with no time-window restriction.

## Backend
- **Schema:** `DoctorProfile.acceptingInstant`, `Appointment.isInstant`, and `Appointment.slotId` is now nullable (`slot` relation optional). Postgres allows multiple NULLs under the existing `@unique` on `slotId`.
- **`POST /api/appointments/instant`** (`@Roles('patient')`, body `{ doctorId }`): creates an instant `PENDING` appointment and notifies the doctor (`APPOINTMENT_REQUEST` via the same Socket.IO `emitToUser` path as `book`). Rejects with a clear `409` if the doctor's `acceptingInstant` is false.
- **`confirm()`** branches its notification text so it never touches `slot.startTime` for instant appts.
- **`getLivekitToken()`** skips the join-window check entirely for instant appts (room open immediately while `CONFIRMED` + `livekitRoom` set).
- Listing/serialization (`listMine`, `cancel`) is null-safe for a missing slot; ordering falls back to `createdAt`.
- **`PATCH /api/doctors/me/instant`** (doctors module, since `DoctorProfile` is owned there) toggles `acceptingInstant`. `getDoctorById` now returns `acceptingInstant`.

## Shared types
`isInstant` + optional `slot`/`slotId` on `Appointment`; `acceptingInstant` on `DoctorProfile`.

## Frontend
- Doctor dashboard: "Instant consultations" toggle (`InstantToggle`) that PATCHes the new endpoint and reflects current state.
- Patient doctor profile (`doctors/[id]`): "Start instant consultation" button shown when `acceptingInstant`; creates the appointment and routes to the patient appointment detail page to await confirm and join via the existing `ConsultationSession`.
- All appointment list/detail/records views render **"Instant / Now"** instead of a slot date/time for slotless appts, and allow joining an instant room as soon as it is confirmed.

## Migration path
The dev DB (`db:5432`) is only reachable on the internal Docker network, **not** from this environment, so the migration was **hand-written** at `apps/api/prisma/migrations/20260530120000_instant_appointments/migration.sql` (ALTER TABLE: add columns + drop NOT NULL on `slotId`), consistent with existing migrations. `prisma generate` was run so the client matches the schema. **Run `prisma migrate deploy` (or `migrate dev`) against a reachable DB before deploying.**

## Deferred (out of scope for this MVP)
- Auto-timeout of unconfirmed instant requests
- Explicit decline by the doctor
- Concurrency locking / single-active-instant enforcement

## Verify end-to-end
1. As a doctor: open the doctor dashboard, flip the **Instant consultations** toggle on.
2. As a patient: open that doctor's profile (`/doctors/<id>`) — the **Start instant consultation** button appears. Click it; you're routed to the appointment detail page (status PENDING).
3. As the doctor: open the appointment, **Confirm** it (mints the LiveKit room).
4. Both sides: **Join session** is immediately available (no time window). Video connects.

Builds: `pnpm --filter @lunasol/api build`, `pnpm --filter @lunasol/web build`, and `pnpm lint` all pass.
