### PR TITLE
Release: promote main to prod

### DIFF
--- a/apps/api/prisma/migrations/20260530120000_instant_appointments/migration.sql
+++ b/apps/api/prisma/migrations/20260530120000_instant_appointments/migration.sql
@@ -1,0 +1,10 @@
+-- Instant (on-demand) appointments.
+-- Doctors opt in via `acceptingInstant`; instant appointments have no pre-booked
+-- slot, so `slotId` becomes nullable and `isInstant` flags the on-demand flow.
+
+-- DoctorProfile: opt-in presence toggle.
+ALTER TABLE "DoctorProfile" ADD COLUMN "acceptingInstant" BOOLEAN NOT NULL DEFAULT false;
+
+-- Appointment: slot is now optional; add the instant flag.
+ALTER TABLE "Appointment" ADD COLUMN "isInstant" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Appointment" ALTER COLUMN "slotId" DROP NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -60,6 +60,7 @@ model DoctorProfile {
   specialization    String
   profilePictureUrl String?
   contactDetails    String?
+  acceptingInstant  Boolean            @default(false)
   slots             AvailabilitySlot[]
   appointments      Appointment[]
 }
@@ -84,8 +85,9 @@ model Appointment {
   patient   PatientProfile     @relation(fields: [patientId], references: [id])
   doctorId  String
   doctor    DoctorProfile      @relation(fields: [doctorId], references: [id])
-  slotId    String             @unique
-  slot      AvailabilitySlot   @relation(fields: [slotId], references: [id])
+  slotId    String?            @unique
+  slot      AvailabilitySlot?  @relation(fields: [slotId], references: [id])
+  isInstant Boolean            @default(false)
   status      AppointmentStatus  @default(PENDING)
   livekitRoom String?
   createdAt DateTime           @default(now())

--- a/apps/api/src/appointments/appointments.controller.ts
+++ b/apps/api/src/appointments/appointments.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, Get, Patch, Param, Body, Req, Query } from '@nestjs/c
 import { Roles } from '../auth/decorators/roles.decorator'
 import { AppointmentsService } from './appointments.service'
 import { BookAppointmentDto } from './dto/book-appointment.dto'
+import { InstantAppointmentDto } from './dto/instant-appointment.dto'
 import { RescheduleAppointmentDto } from './dto/reschedule-appointment.dto'
 
 @Controller('appointments')
@@ -12,6 +13,12 @@ export class AppointmentsController {
   @Post()
   book(@Req() req: any, @Body() dto: BookAppointmentDto) {
     return this.appointmentsService.book(req.user.id, dto)
+  }
+
+  @Roles('patient')
+  @Post('instant')
+  createInstant(@Req() req: any, @Body() dto: InstantAppointmentDto) {
+    return this.appointmentsService.createInstant(req.user.id, dto)
   }
 
   @Roles('patient', 'doctor')

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -10,6 +10,7 @@ import { AccessToken, WebhookReceiver } from 'livekit-server-sdk'
 import { PrismaService } from '../prisma/prisma.service'
 import { NotificationsService } from '../notifications/notifications.service'
 import { BookAppointmentDto } from './dto/book-appointment.dto'
+import { InstantAppointmentDto } from './dto/instant-appointment.dto'
 import { RescheduleAppointmentDto } from './dto/reschedule-appointment.dto'
 import { AppointmentStatus } from '@prisma/client'
 
@@ -102,13 +103,46 @@ export class AppointmentsService {
     }
   }
 
+  async createInstant(clerkId: string, dto: InstantAppointmentDto) {
+    const { patient } = await this.getPatientProfile(clerkId)
+
+    const doctor = await this.prisma.doctorProfile.findUnique({
+      where: { id: dto.doctorId },
+      include: { user: true },
+    })
+    if (!doctor) throw new NotFoundException('Doctor not found')
+    if (!doctor.acceptingInstant) {
+      throw new ConflictException('This doctor is not accepting instant consultations right now')
+    }
+
+    const appointment = await this.prisma.appointment.create({
+      data: {
+        patientId: patient.id,
+        doctorId: doctor.id,
+        slotId: null,
+        isInstant: true,
+        status: AppointmentStatus.PENDING,
+      },
+      include: { slot: true, doctor: true, patient: true },
+    })
+
+    await this.createNotification(
+      doctor.user.id,
+      'APPOINTMENT_REQUEST',
+      `${patient.name} is requesting an instant consultation now`,
+    )
+
+    return appointment
+  }
+
   async listMine(clerkId: string, role: string, patientId?: string) {
     if (role === 'doctor') {
       const { doctor } = await this.getDoctorProfile(clerkId)
       return this.prisma.appointment.findMany({
         where: { doctorId: doctor.id, ...(patientId ? { patientId } : {}) },
         include: { slot: true, patient: true, record: { include: { prescriptions: true } } },
-        orderBy: { slot: { startTime: 'asc' } },
+        // slot may be null for instant appointments; fall back to creation order.
+        orderBy: [{ slot: { startTime: 'asc' } }, { createdAt: 'asc' }],
       })
     }
 
@@ -116,7 +150,8 @@ export class AppointmentsService {
     return this.prisma.appointment.findMany({
       where: { patientId: patient.id },
       include: { slot: true, doctor: true, record: { include: { prescriptions: true } } },
-      orderBy: { slot: { startTime: 'asc' } },
+      // slot may be null for instant appointments; fall back to creation order.
+      orderBy: [{ slot: { startTime: 'asc' } }, { createdAt: 'asc' }],
     })
   }
 
@@ -146,7 +181,9 @@ export class AppointmentsService {
     await this.createNotification(
       appointment.doctor.user.id,
       'APPOINTMENT_CANCELLED',
-      `${patient.name} cancelled their appointment on ${appointment.slot.startTime.toLocaleDateString()}`,
+      appointment.isInstant || !appointment.slot
+        ? `${patient.name} cancelled their instant consultation request`
+        : `${patient.name} cancelled their appointment on ${appointment.slot.startTime.toLocaleDateString()}`,
     )
 
     return updated
@@ -235,7 +272,9 @@ export class AppointmentsService {
     await this.createNotification(
       appointment.patient.user.id,
       'APPOINTMENT_CONFIRMED',
-      `Your appointment on ${appointment.slot.startTime.toLocaleDateString()} has been confirmed. Join the session when it's time.`,
+      appointment.isInstant || !appointment.slot
+        ? `Your instant consultation has been confirmed. Join the session now.`
+        : `Your appointment on ${appointment.slot.startTime.toLocaleDateString()} has been confirmed. Join the session when it's time.`,
     )
 
     return updated
@@ -308,15 +347,19 @@ export class AppointmentsService {
       throw new ConflictException('Session not available')
     }
 
-    // Enforce the join window server-side. The client gates the "Join" button on
-    // the same window, but the token endpoint must not be joinable out-of-band.
-    const now = Date.now()
-    const start = appointment.slot.startTime.getTime()
-    const end = appointment.slot.endTime.getTime()
-    if (now < start - JOIN_LEAD_MS || now > end) {
-      throw new ForbiddenException(
-        'The consultation room is only open from 5 minutes before the appointment until it ends',
-      )
+    // Enforce the join window server-side for scheduled appointments. The client
+    // gates the "Join" button on the same window, but the token endpoint must not
+    // be joinable out-of-band. Instant appointments have no slot, so the room is
+    // open immediately while the appointment is CONFIRMED.
+    if (!appointment.isInstant && appointment.slot) {
+      const now = Date.now()
+      const start = appointment.slot.startTime.getTime()
+      const end = appointment.slot.endTime.getTime()
+      if (now < start - JOIN_LEAD_MS || now > end) {
+        throw new ForbiddenException(
+          'The consultation room is only open from 5 minutes before the appointment until it ends',
+        )
+      }
     }
 
     const apiKey = process.env.LIVEKIT_API_KEY

--- a/apps/api/src/appointments/dto/instant-appointment.dto.ts
+++ b/apps/api/src/appointments/dto/instant-appointment.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator'
+
+export class InstantAppointmentDto {
+  @IsString()
+  @IsNotEmpty()
+  doctorId!: string
+}

--- a/apps/api/src/doctors/doctors.controller.ts
+++ b/apps/api/src/doctors/doctors.controller.ts
@@ -21,6 +21,7 @@ import { Roles } from '../auth/decorators/roles.decorator'
 import { Public } from '../auth/decorators/public.decorator'
 import { DoctorsService } from './doctors.service'
 import { UpdateDoctorProfileDto } from './dto/update-doctor-profile.dto'
+import { UpdateInstantDto } from './dto/update-instant.dto'
 import { CreateAvailabilitySlotDto } from './dto/create-availability-slot.dto'
 
 const uploadDir = join(process.cwd(), 'uploads', 'profile-pictures')
@@ -66,6 +67,12 @@ export class DoctorsController implements OnModuleInit {
   @Patch('me')
   async updateProfile(@Req() req: any, @Body() dto: UpdateDoctorProfileDto) {
     return this.doctorsService.updateProfile(req.user.id, dto)
+  }
+
+  @Roles('doctor')
+  @Patch('me/instant')
+  async setAcceptingInstant(@Req() req: any, @Body() dto: UpdateInstantDto) {
+    return this.doctorsService.setAcceptingInstant(req.user.id, dto.acceptingInstant)
   }
 
   @Roles('doctor')

--- a/apps/api/src/doctors/doctors.service.ts
+++ b/apps/api/src/doctors/doctors.service.ts
@@ -78,6 +78,7 @@ export class DoctorsService {
         bio: true,
         profilePictureUrl: true,
         contactDetails: true,
+        acceptingInstant: true,
       },
     })
 
@@ -167,6 +168,18 @@ export class DoctorsService {
     const updated = await this.prisma.doctorProfile.update({
       where: { id: user.doctor!.id },
       data: { profilePictureUrl: `/api/uploads/profile-pictures/${filename}` },
+    })
+
+    const profileComplete = !!updated.bio && updated.bio.trim().length > 0
+    return { ...updated, profileComplete }
+  }
+
+  async setAcceptingInstant(clerkId: string, acceptingInstant: boolean) {
+    const user = await this.ensureDoctorRecord(clerkId)
+
+    const updated = await this.prisma.doctorProfile.update({
+      where: { id: user.doctor!.id },
+      data: { acceptingInstant },
     })
 
     const profileComplete = !!updated.bio && updated.bio.trim().length > 0

--- a/apps/api/src/doctors/dto/update-instant.dto.ts
+++ b/apps/api/src/doctors/dto/update-instant.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator'
+
+export class UpdateInstantDto {
+  @IsBoolean()
+  acceptingInstant!: boolean
+}

--- a/apps/web/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/web/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useSignUp } from '@clerk/nextjs'
+import { useSignUp } from '@clerk/nextjs/legacy'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
 export default function SignUpPage() {
-  const { signUp } = useSignUp()
+  const { isLoaded, signUp, setActive } = useSignUp()
   const [emailAddress, setEmailAddress] = useState('')
   const [password, setPassword] = useState('')
   const [role, setRole] = useState<'patient' | 'doctor'>('patient')
@@ -15,33 +15,28 @@ export default function SignUpPage() {
   const [loading, setLoading] = useState(false)
   const router = useRouter()
 
-  const isLoaded = signUp !== undefined && signUp !== null
   if (!isLoaded) return null
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    if (!isLoaded) return
     setError('')
     setLoading(true)
     try {
-      const createRes = await signUp.create({
+      await signUp.create({
         emailAddress,
         password,
         unsafeMetadata: { role },
       })
-      if (createRes.error) {
-        setError(createRes.error.message || 'An error occurred during sign up.')
-        return
-      }
-      
-      const sendRes = await signUp.verifications.sendEmailCode()
-      if (sendRes.error) {
-        setError(sendRes.error.message || 'Failed to send verification code.')
-        return
-      }
+      await signUp.prepareEmailAddressVerification({ strategy: 'email_code' })
       setPendingVerification(true)
     } catch (err) {
       const errorObject = err as any
-      setError(errorObject.message || 'An error occurred during sign up.')
+      setError(
+        errorObject.errors?.[0]?.longMessage ||
+          errorObject.errors?.[0]?.message ||
+          'An error occurred during sign up.',
+      )
     } finally {
       setLoading(false)
     }
@@ -49,28 +44,25 @@ export default function SignUpPage() {
 
   async function handleVerify(e: React.FormEvent) {
     e.preventDefault()
+    if (!isLoaded) return
     setError('')
     setLoading(true)
     try {
-      const verifyRes = await signUp.verifications.verifyEmailCode({ code })
-      if (verifyRes.error) {
-        setError(verifyRes.error.message || 'Verification failed. Please try again.')
-        return
-      }
-      
-      if (signUp.status === 'complete') {
-        const finalizeRes = await signUp.finalize()
-        if (finalizeRes.error) {
-          setError(finalizeRes.error.message || 'Failed to finalize sign up.')
-          return
-        }
+      const result = await signUp.attemptEmailAddressVerification({ code })
+
+      if (result.status === 'complete') {
+        await setActive({ session: result.createdSessionId })
         router.push('/dashboard')
       } else {
         setError('Verification failed. Please try again.')
       }
     } catch (err) {
       const errorObject = err as any
-      setError(errorObject.message || 'Verification failed. Please try again.')
+      setError(
+        errorObject.errors?.[0]?.longMessage ||
+          errorObject.errors?.[0]?.message ||
+          'Verification failed. Please try again.',
+      )
     } finally {
       setLoading(false)
     }

--- a/apps/web/src/app/dashboard/doctor/appointments/[id]/PatientHistory.tsx
+++ b/apps/web/src/app/dashboard/doctor/appointments/[id]/PatientHistory.tsx
@@ -16,7 +16,8 @@ interface Prescription {
 interface Appointment {
   id: string
   status: string
-  slot: { startTime: string }
+  isInstant?: boolean
+  slot: { startTime: string } | null
   record: { notes: string | null; prescriptions: Prescription[] } | null
 }
 
@@ -64,11 +65,13 @@ export default function PatientHistory({ patientId, currentAppointmentId }: { pa
           ) : (
             <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', paddingTop: '20px' }}>
               {history.map((a) => {
-                const date = new Date(a.slot.startTime)
+                const date = a.slot ? new Date(a.slot.startTime) : null
                 return (
                   <div key={a.id} style={{ background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '8px', padding: '16px' }}>
                     <p style={{ fontSize: '13px', fontWeight: 700, color: '#374151', margin: '0 0 8px' }}>
-                      {date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
+                      {date
+                        ? date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+                        : 'Instant consultation'}
                     </p>
                     {a.record?.notes ? (
                       <p style={{ fontSize: '14px', color: '#4b5563', lineHeight: 1.6, margin: '0 0 8px', whiteSpace: 'pre-line' }}>{a.record.notes}</p>

--- a/apps/web/src/app/dashboard/doctor/appointments/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/doctor/appointments/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
-import { ArrowLeft, Calendar, Clock, User, Video } from 'lucide-react'
+import { ArrowLeft, Calendar, Clock, User, Video, Zap } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import ConsultationSession from '@/components/ConsultationSession'
 import ConsultationPanel from './ConsultationPanel'
@@ -13,8 +13,9 @@ interface Appointment {
   id: string
   status: 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'COMPLETED'
   livekitRoom: string | null
+  isInstant: boolean
   patient: { id: string; name: string; profilePictureUrl: string | null }
-  slot: { startTime: string; endTime: string }
+  slot: { startTime: string; endTime: string } | null
 }
 
 const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
@@ -75,11 +76,13 @@ export default function DoctorAppointmentDetailPage() {
     return <ConsultationSession appointmentId={appt.id} onLeave={() => { setInSession(false); load() }} />
   }
 
-  const date = appt ? new Date(appt.slot.startTime) : null
+  const isInstant = !!appt?.isInstant || (!!appt && !appt.slot)
+  const date = appt?.slot ? new Date(appt.slot.startTime) : null
   const statusStyle = appt ? STATUS_COLORS[appt.status] : null
-  const start = appt ? new Date(appt.slot.startTime).getTime() : 0
-  const end = appt ? new Date(appt.slot.endTime).getTime() : 0
-  const withinWindow = now >= start - JOIN_LEAD_MS && now <= end
+  const start = appt?.slot ? new Date(appt.slot.startTime).getTime() : 0
+  const end = appt?.slot ? new Date(appt.slot.endTime).getTime() : 0
+  // Instant consultations have no slot window — joinable as soon as confirmed.
+  const withinWindow = isInstant || (now >= start - JOIN_LEAD_MS && now <= end)
   const canJoin = appt?.status === 'CONFIRMED' && !!appt.livekitRoom && withinWindow
 
   return (
@@ -123,12 +126,20 @@ export default function DoctorAppointmentDetailPage() {
               </div>
 
               <div style={{ display: 'flex', gap: '24px', paddingBottom: '24px', borderBottom: '1px solid #f3f4f6' }}>
-                <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#4b5563' }}>
-                  <Calendar size={16} color="#9ca3af" /> {date!.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}
-                </span>
-                <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#4b5563' }}>
-                  <Clock size={16} color="#9ca3af" /> {date!.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
-                </span>
+                {isInstant || !date ? (
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#059669', fontWeight: 600 }}>
+                    <Zap size={16} /> Instant consultation · Now
+                  </span>
+                ) : (
+                  <>
+                    <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#4b5563' }}>
+                      <Calendar size={16} color="#9ca3af" /> {date.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}
+                    </span>
+                    <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', color: '#4b5563' }}>
+                      <Clock size={16} color="#9ca3af" /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
+                    </span>
+                  </>
+                )}
               </div>
 
               <div style={{ display: 'flex', gap: '10px', marginTop: '24px', flexWrap: 'wrap' }}>

--- a/apps/web/src/app/dashboard/doctor/appointments/page.tsx
+++ b/apps/web/src/app/dashboard/doctor/appointments/page.tsx
@@ -3,14 +3,15 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
-import { Calendar, Clock, User } from 'lucide-react'
+import { Calendar, Clock, User, Zap } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 
 interface Appointment {
   id: string
   status: 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'COMPLETED'
+  isInstant: boolean
   patient: { id: string; name: string; profilePictureUrl: string | null }
-  slot: { startTime: string; endTime: string }
+  slot: { startTime: string; endTime: string } | null
 }
 
 const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
@@ -93,7 +94,8 @@ export default function DoctorAppointmentsPage() {
 
 function AppointmentCard({ appt, onClick }: { appt: Appointment; onClick: () => void }) {
   const statusStyle = STATUS_COLORS[appt.status] || { bg: '#f3f4f6', text: '#374151' }
-  const date = new Date(appt.slot.startTime)
+  const isInstant = appt.isInstant || !appt.slot
+  const date = appt.slot ? new Date(appt.slot.startTime) : null
 
   return (
     <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '20px 24px', cursor: 'pointer' }} onClick={onClick}>
@@ -110,12 +112,20 @@ function AppointmentCard({ appt, onClick }: { appt: Appointment; onClick: () => 
       </div>
 
       <div style={{ display: 'flex', gap: '20px' }}>
-        <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
-          <Calendar size={14} /> {date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
-        </span>
-        <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
-          <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
-        </span>
+        {isInstant || !date ? (
+          <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#059669', fontWeight: 600 }}>
+            <Zap size={14} /> Instant · Now
+          </span>
+        ) : (
+          <>
+            <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+              <Calendar size={14} /> {date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+            </span>
+            <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+              <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
+            </span>
+          </>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/app/dashboard/doctor/appointments/page.tsx
+++ b/apps/web/src/app/dashboard/doctor/appointments/page.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
-import { Calendar, Clock, User } from 'lucide-react'
+import { Calendar, Clock, User, Hourglass } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
+import { formatTimeRemaining, useNow } from '@/lib/time'
 
 interface Appointment {
   id: string
@@ -94,6 +95,9 @@ export default function DoctorAppointmentsPage() {
 function AppointmentCard({ appt, onClick }: { appt: Appointment; onClick: () => void }) {
   const statusStyle = STATUS_COLORS[appt.status] || { bg: '#f3f4f6', text: '#374151' }
   const date = new Date(appt.slot.startTime)
+  const isUpcoming = appt.status === 'PENDING' || appt.status === 'CONFIRMED'
+  const now = useNow()
+  const timeRemaining = isUpcoming ? formatTimeRemaining(appt.slot.startTime, now) : null
 
   return (
     <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '20px 24px', cursor: 'pointer' }} onClick={onClick}>
@@ -116,6 +120,11 @@ function AppointmentCard({ appt, onClick }: { appt: Appointment; onClick: () => 
         <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
           <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
         </span>
+        {timeRemaining && (
+          <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+            <Hourglass size={14} /> {timeRemaining}
+          </span>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/app/dashboard/doctor/components/InstantToggle.tsx
+++ b/apps/web/src/app/dashboard/doctor/components/InstantToggle.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useAuth } from '@clerk/nextjs'
+import { Zap } from 'lucide-react'
+import { apiFetch } from '@/lib/api'
+
+export default function InstantToggle() {
+  const { getToken } = useAuth()
+  const [accepting, setAccepting] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        const token = await getToken()
+        const data = await apiFetch('/doctors/me', { token: token || undefined })
+        setAccepting(!!data.acceptingInstant)
+      } catch {
+        // keep default
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [getToken])
+
+  async function toggle() {
+    const next = !accepting
+    setSaving(true)
+    setError('')
+    // Optimistic update.
+    setAccepting(next)
+    try {
+      const token = await getToken()
+      await apiFetch('/doctors/me/instant', {
+        token: token || undefined,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ acceptingInstant: next }),
+      })
+    } catch (err: any) {
+      setAccepting(!next)
+      setError(err.message || 'Failed to update. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '24px', marginBottom: '32px', display: 'flex', alignItems: 'center', gap: '20px', flexWrap: 'wrap' }}>
+      <div style={{ display: 'flex', padding: '12px', background: accepting ? '#ecfdf5' : '#f3f4f6', borderRadius: '12px', color: accepting ? '#059669' : '#9ca3af' }}>
+        <Zap size={24} />
+      </div>
+      <div style={{ flex: 1, minWidth: '240px' }}>
+        <h3 style={{ fontSize: '16px', fontWeight: 600, margin: '0 0 4px', color: '#111827' }}>Instant consultations</h3>
+        <p style={{ fontSize: '14px', color: '#6b7280', margin: 0, lineHeight: 1.5 }}>
+          {accepting
+            ? 'You appear as available now. Patients can start an instant consultation request with you.'
+            : 'Turn this on to let patients start an on-demand consultation with you right now.'}
+        </p>
+        {error && <p style={{ fontSize: '13px', color: '#dc2626', margin: '8px 0 0' }}>{error}</p>}
+      </div>
+      <button
+        onClick={toggle}
+        disabled={loading || saving}
+        aria-pressed={accepting}
+        style={{
+          position: 'relative',
+          width: '52px',
+          height: '30px',
+          borderRadius: '15px',
+          border: 'none',
+          background: accepting ? '#10b981' : '#d1d5db',
+          cursor: loading || saving ? 'not-allowed' : 'pointer',
+          transition: 'background 0.15s',
+          flexShrink: 0,
+        }}
+      >
+        <span
+          style={{
+            position: 'absolute',
+            top: '3px',
+            left: accepting ? '25px' : '3px',
+            width: '24px',
+            height: '24px',
+            borderRadius: '50%',
+            background: '#ffffff',
+            transition: 'left 0.15s',
+          }}
+        />
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/app/dashboard/doctor/page.tsx
+++ b/apps/web/src/app/dashboard/doctor/page.tsx
@@ -2,6 +2,7 @@ import { UserButton } from '@clerk/nextjs'
 import { currentUser } from '@clerk/nextjs/server'
 import { Video, Users, Clock, ClipboardList } from 'lucide-react'
 import NotificationBell from '@/components/NotificationBell'
+import InstantToggle from './components/InstantToggle'
 
 export default async function DoctorDashboard() {
   const user = await currentUser()
@@ -39,6 +40,8 @@ export default async function DoctorDashboard() {
             Access and manage your patients, clinical schedule, and appointments in real-time.
           </p>
         </div>
+
+        <InstantToggle />
 
         {/* Quick Stats / Actions */}
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '24px', marginBottom: '40px' }}>

--- a/apps/web/src/app/dashboard/patient/appointments/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/patient/appointments/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
-import { Calendar, Clock, Video, ArrowLeft } from 'lucide-react'
+import { Calendar, Clock, Video, ArrowLeft, Zap } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import ConsultationSession from '@/components/ConsultationSession'
 
@@ -11,8 +11,9 @@ interface Appointment {
   id: string
   status: 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'COMPLETED'
   livekitRoom: string | null
+  isInstant: boolean
   doctor: { id: string; name: string; specialization: string }
-  slot: { startTime: string; endTime: string }
+  slot: { startTime: string; endTime: string } | null
 }
 
 const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
@@ -58,9 +59,11 @@ export default function PatientAppointmentDetail() {
     return <ConsultationSession appointmentId={appt.id} onLeave={() => setInSession(false)} />
   }
 
-  const start = appt ? new Date(appt.slot.startTime).getTime() : 0
-  const end = appt ? new Date(appt.slot.endTime).getTime() : 0
-  const withinWindow = now >= start - JOIN_LEAD_MS && now <= end
+  const isInstant = !!appt?.isInstant || !appt?.slot
+  const start = appt?.slot ? new Date(appt.slot.startTime).getTime() : 0
+  const end = appt?.slot ? new Date(appt.slot.endTime).getTime() : 0
+  // Instant consultations have no slot window — the room is open as soon as it's confirmed.
+  const withinWindow = isInstant || (now >= start - JOIN_LEAD_MS && now <= end)
   const canJoin = appt?.status === 'CONFIRMED' && !!appt.livekitRoom && withinWindow
   const statusStyle = (appt && STATUS_COLORS[appt.status]) || { bg: '#f3f4f6', text: '#374151' }
 
@@ -90,12 +93,20 @@ export default function PatientAppointmentDetail() {
             </div>
 
             <div style={{ display: 'flex', gap: '24px', marginBottom: '28px' }}>
-              <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px', color: '#374151' }}>
-                <Calendar size={16} /> {new Date(appt.slot.startTime).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}
-              </span>
-              <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px', color: '#374151' }}>
-                <Clock size={16} /> {new Date(appt.slot.startTime).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
-              </span>
+              {isInstant || !appt.slot ? (
+                <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px', color: '#059669', fontWeight: 600 }}>
+                  <Zap size={16} /> Instant consultation · Now
+                </span>
+              ) : (
+                <>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px', color: '#374151' }}>
+                    <Calendar size={16} /> {new Date(appt.slot.startTime).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}
+                  </span>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px', color: '#374151' }}>
+                    <Clock size={16} /> {new Date(appt.slot.startTime).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
+                  </span>
+                </>
+              )}
             </div>
 
             {appt.status === 'CONFIRMED' && (

--- a/apps/web/src/app/dashboard/patient/appointments/page.tsx
+++ b/apps/web/src/app/dashboard/patient/appointments/page.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
-import { Calendar, Clock } from 'lucide-react'
+import { Calendar, Clock, Hourglass } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
+import { formatTimeRemaining, useNow } from '@/lib/time'
 
 interface Appointment {
   id: string
@@ -117,6 +118,8 @@ function AppointmentCard({ appt, onCancel, cancelling, onClick }: {
   const statusStyle = STATUS_COLORS[appt.status] || { bg: '#f3f4f6', text: '#374151' }
   const date = new Date(appt.slot.startTime)
   const canCancel = appt.status === 'PENDING' || appt.status === 'CONFIRMED'
+  const now = useNow()
+  const timeRemaining = canCancel ? formatTimeRemaining(appt.slot.startTime, now) : null
 
   return (
     <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '20px 24px', cursor: 'pointer' }} onClick={onClick}>
@@ -137,6 +140,11 @@ function AppointmentCard({ appt, onCancel, cancelling, onClick }: {
         <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
           <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
         </span>
+        {timeRemaining && (
+          <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+            <Hourglass size={14} /> {timeRemaining}
+          </span>
+        )}
       </div>
 
       {canCancel && (

--- a/apps/web/src/app/dashboard/patient/appointments/page.tsx
+++ b/apps/web/src/app/dashboard/patient/appointments/page.tsx
@@ -3,14 +3,15 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
-import { Calendar, Clock } from 'lucide-react'
+import { Calendar, Clock, Zap } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 
 interface Appointment {
   id: string
   status: 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'COMPLETED'
+  isInstant: boolean
   doctor: { id: string; name: string; specialization: string; profilePictureUrl: string | null }
-  slot: { startTime: string; endTime: string }
+  slot: { startTime: string; endTime: string } | null
 }
 
 const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
@@ -115,7 +116,8 @@ function AppointmentCard({ appt, onCancel, cancelling, onClick }: {
   onClick: () => void
 }) {
   const statusStyle = STATUS_COLORS[appt.status] || { bg: '#f3f4f6', text: '#374151' }
-  const date = new Date(appt.slot.startTime)
+  const isInstant = appt.isInstant || !appt.slot
+  const date = appt.slot ? new Date(appt.slot.startTime) : null
   const canCancel = appt.status === 'PENDING' || appt.status === 'CONFIRMED'
 
   return (
@@ -131,12 +133,20 @@ function AppointmentCard({ appt, onCancel, cancelling, onClick }: {
       </div>
 
       <div style={{ display: 'flex', gap: '20px', marginBottom: canCancel ? '16px' : '0' }}>
-        <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
-          <Calendar size={14} /> {date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
-        </span>
-        <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
-          <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
-        </span>
+        {isInstant || !date ? (
+          <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#059669', fontWeight: 600 }}>
+            <Zap size={14} /> Instant · Now
+          </span>
+        ) : (
+          <>
+            <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+              <Calendar size={14} /> {date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+            </span>
+            <span style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+              <Clock size={14} /> {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })}
+            </span>
+          </>
+        )}
       </div>
 
       {canCancel && (

--- a/apps/web/src/app/dashboard/patient/records/page.tsx
+++ b/apps/web/src/app/dashboard/patient/records/page.tsx
@@ -23,7 +23,8 @@ interface ConsultationRecord {
 interface Appointment {
   id: string
   status: string
-  slot: { startTime: string }
+  isInstant?: boolean
+  slot: { startTime: string } | null
   doctor: { name: string; specialization: string }
   record: ConsultationRecord | null
 }
@@ -73,7 +74,10 @@ export default function RecordsPage() {
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
             {appointments.map((appt) => {
               const isOpen = expanded === appt.id
-              const date = new Date(appt.slot.startTime)
+              const date = appt.slot ? new Date(appt.slot.startTime) : null
+              const dateLabel = date
+                ? date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+                : 'Instant consultation'
 
               return (
                 <div key={appt.id} style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', overflow: 'hidden' }}>
@@ -84,7 +88,7 @@ export default function RecordsPage() {
                     <div>
                       <p style={{ fontSize: '16px', fontWeight: 700, color: '#111827', margin: '0 0 4px' }}>{appt.doctor.name}</p>
                       <p style={{ fontSize: '13px', color: '#6b7280', margin: 0 }}>
-                        {appt.doctor.specialization} · {date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
+                        {appt.doctor.specialization} · {dateLabel}
                       </p>
                     </div>
                     {isOpen ? <ChevronUp size={18} color="#6b7280" /> : <ChevronDown size={18} color="#6b7280" />}

--- a/apps/web/src/app/doctors/[id]/page.tsx
+++ b/apps/web/src/app/doctors/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { useAuth, Show, UserButton } from '@clerk/nextjs'
-import { User, Calendar, Clock, ArrowLeft } from 'lucide-react'
+import { User, Calendar, Clock, ArrowLeft, Zap } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 
 interface Doctor {
@@ -13,6 +13,7 @@ interface Doctor {
   bio: string | null
   profilePictureUrl: string | null
   contactDetails: string | null
+  acceptingInstant?: boolean
 }
 
 interface Slot {
@@ -42,6 +43,7 @@ export default function DoctorDetailPage() {
   const [booking, setBooking] = useState(false)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState(false)
+  const [startingInstant, setStartingInstant] = useState(false)
 
   useEffect(() => {
     async function load() {
@@ -82,6 +84,29 @@ export default function DoctorDetailPage() {
       setError(err.message || 'Booking failed. Please try again.')
     } finally {
       setBooking(false)
+    }
+  }
+
+  async function handleStartInstant() {
+    if (!isSignedIn) {
+      router.push('/sign-in')
+      return
+    }
+
+    setStartingInstant(true)
+    setError('')
+    try {
+      const token = await getToken()
+      const appt = await apiFetch('/appointments/instant', {
+        token: token || undefined,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ doctorId: id }),
+      })
+      router.push(`/dashboard/patient/appointments/${appt.id}`)
+    } catch (err: any) {
+      setError(err.message || 'Could not start instant consultation. Please try again.')
+      setStartingInstant(false)
     }
   }
 
@@ -160,6 +185,39 @@ export default function DoctorDetailPage() {
 
         {/* Slot picker */}
         <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '16px', padding: '24px', position: 'sticky', top: '80px' }}>
+          {doctor.acceptingInstant && (
+            <div style={{ marginBottom: '20px', paddingBottom: '20px', borderBottom: '1px solid #f3f4f6' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
+                <Zap size={18} color="#059669" />
+                <h2 style={{ fontSize: '16px', fontWeight: 700, margin: 0 }}>Available now</h2>
+              </div>
+              <p style={{ fontSize: '13px', color: '#6b7280', margin: '0 0 14px', lineHeight: 1.5 }}>
+                This doctor is online. Start a consultation right now without booking a slot.
+              </p>
+              <button
+                onClick={handleStartInstant}
+                disabled={startingInstant}
+                style={{
+                  width: '100%',
+                  padding: '12px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: '8px',
+                  background: startingInstant ? '#a7f3d0' : '#059669',
+                  border: 'none',
+                  borderRadius: '8px',
+                  color: '#ffffff',
+                  fontSize: '14px',
+                  fontWeight: 600,
+                  cursor: startingInstant ? 'not-allowed' : 'pointer',
+                }}
+              >
+                <Zap size={16} /> {startingInstant ? 'Starting...' : !isSignedIn ? 'Sign in to start' : 'Start instant consultation'}
+              </button>
+            </div>
+          )}
+
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '20px' }}>
             <Calendar size={18} color="#111827" />
             <h2 style={{ fontSize: '16px', fontWeight: 700, margin: 0 }}>Available slots</h2>

--- a/apps/web/src/app/doctors/[id]/page.tsx
+++ b/apps/web/src/app/doctors/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter, useParams } from 'next/navigation'
-import { useAuth } from '@clerk/nextjs'
+import { useAuth, Show, UserButton } from '@clerk/nextjs'
 import { User, Calendar, Clock, ArrowLeft } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 
@@ -110,6 +110,16 @@ export default function DoctorDetailPage() {
           <ArrowLeft size={16} /> Back
         </button>
         <span style={{ fontSize: '18px', fontWeight: 700, color: '#111827', letterSpacing: '-0.5px' }}>LunaSol</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: '16px', alignItems: 'center' }}>
+          <Show when="signed-out">
+            <a href="/sign-in" style={{ padding: '8px 16px', border: '1px solid #cbd5e1', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#475569', textDecoration: 'none' }}>Sign In</a>
+            <a href="/sign-up" style={{ padding: '8px 16px', background: '#0f172a', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#ffffff', textDecoration: 'none' }}>Sign Up</a>
+          </Show>
+          <Show when="signed-in">
+            <a href="/dashboard" style={{ fontSize: '14px', fontWeight: 600, color: '#111827', textDecoration: 'none' }}>Dashboard</a>
+            <UserButton />
+          </Show>
+        </div>
       </nav>
 
       <main style={{ maxWidth: '900px', margin: '0 auto', padding: '40px 24px', display: 'grid', gridTemplateColumns: '1fr 360px', gap: '32px', alignItems: 'start' }}>

--- a/apps/web/src/app/doctors/page.tsx
+++ b/apps/web/src/app/doctors/page.tsx
@@ -443,8 +443,26 @@ export default function DoctorsPage() {
             )}
           </div>
 
-          {/* 2. Symptom Input Area & Conversational Flow */}
-          {messages.length === 0 ? (
+          {/* 2. Symptom Input Area & Conversational Flow.
+                When the AI service is unavailable, hide both the form and the
+                chat and point users to the directory below as a fallback. */}
+          {aiError ? (
+            <div style={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: '12px',
+              background: '#f8fafc',
+              border: '1px solid #e2e8f0',
+              borderRadius: '16px',
+              padding: '16px 20px',
+              color: '#475569',
+              fontSize: '14px',
+              lineHeight: '1.5'
+            }}>
+              <Info size={18} color="#94a3b8" style={{ flexShrink: 0, marginTop: '1px' }} />
+              <span>Smart matching is temporarily unavailable — browse the directory below.</span>
+            </div>
+          ) : messages.length === 0 ? (
             <form onSubmit={handleAiSubmit}>
               <div style={{ position: 'relative', marginBottom: '16px' }}>
                 <textarea

--- a/apps/web/src/app/doctors/page.tsx
+++ b/apps/web/src/app/doctors/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, FormEvent, useRef } from 'react'
 import { useRouter } from 'next/navigation'
+import { Show, UserButton } from '@clerk/nextjs'
 import { Search, Filter, User, Sparkles, AlertTriangle, Send, RefreshCw, X, ArrowRight, ShieldCheck, HeartPulse } from 'lucide-react'
 import { useAiRecommendation, ChatMessage } from '../../lib/useAiRecommendation'
 import { SPECIALIZATIONS as SPECIALIZATION_OPTIONS } from '@lunasol/types'
@@ -308,9 +309,15 @@ export default function DoctorsPage() {
           <HeartPulse size={24} color="#6366f1" />
           <span>LunaSol</span>
         </a>
-        <div style={{ display: 'flex', gap: '16px' }}>
-          <a href="/sign-in" style={{ padding: '8px 16px', border: '1px solid #cbd5e1', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#475569', textDecoration: 'none', transition: 'background-color 0.2s' }}>Sign In</a>
-          <a href="/sign-up" style={{ padding: '8px 16px', background: '#0f172a', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#ffffff', textDecoration: 'none', transition: 'background-color 0.2s' }}>Sign Up</a>
+        <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
+          <Show when="signed-out">
+            <a href="/sign-in" style={{ padding: '8px 16px', border: '1px solid #cbd5e1', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#475569', textDecoration: 'none', transition: 'background-color 0.2s' }}>Sign In</a>
+            <a href="/sign-up" style={{ padding: '8px 16px', background: '#0f172a', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#ffffff', textDecoration: 'none', transition: 'background-color 0.2s' }}>Sign Up</a>
+          </Show>
+          <Show when="signed-in">
+            <a href="/dashboard" style={{ padding: '8px 16px', fontSize: '14px', fontWeight: 600, color: '#0f172a', textDecoration: 'none' }}>Dashboard</a>
+            <UserButton />
+          </Show>
         </div>
       </nav>
 

--- a/apps/web/src/app/doctors/page.tsx
+++ b/apps/web/src/app/doctors/page.tsx
@@ -339,9 +339,9 @@ export default function DoctorsPage() {
             <div>
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px' }}>
                 <Sparkles size={20} color="#6366f1" style={{ filter: 'drop-shadow(0 0 6px rgba(99, 102, 241, 0.4))' }} />
-                <h2 style={{ fontSize: '22px', fontWeight: 800, color: '#0f172a', margin: 0, letterSpacing: '-0.5px' }}>AI-Powered Doctor Matcher</h2>
+                <h2 style={{ fontSize: '22px', fontWeight: 800, color: '#0f172a', margin: 0, letterSpacing: '-0.5px' }}>Find the right specialist</h2>
               </div>
-              <p style={{ fontSize: '14px', color: '#475569', margin: 0 }}>Describe your symptoms, and MedGemma AI will recommend the most appropriate specialists.</p>
+              <p style={{ fontSize: '14px', color: '#475569', margin: 0 }}>Describe your symptoms and we&apos;ll suggest the right specialties.</p>
             </div>
             
             {(messages.length > 0 || reasoning || recommendedDoctors.length > 0 || aiLoading) && (
@@ -496,7 +496,7 @@ export default function DoctorsPage() {
                   ) : (
                     <>
                       <Send size={15} />
-                      <span>Find My Doctor Match</span>
+                      <span>Find a specialist</span>
                     </>
                   )}
                 </button>
@@ -523,7 +523,7 @@ export default function DoctorsPage() {
                 <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px', borderBottom: '1px solid #e2e8f0', paddingBottom: '10px' }}>
                   <div style={{ width: '8px', height: '8px', borderRadius: '50%', background: aiLoading ? '#22c55e' : '#64748b', animation: aiLoading ? 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite' : 'none' }} />
                   <span style={{ fontSize: '12px', fontWeight: 700, color: '#475569', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
-                    {aiLoading ? 'MedGemma 1.5 Chat Active' : 'MedGemma Triage Session'}
+                    {aiLoading ? 'Matching in progress' : 'Symptom assistant'}
                   </span>
                 </div>
 
@@ -578,7 +578,7 @@ export default function DoctorsPage() {
                           color: '#64748b',
                           alignSelf: isUser ? 'flex-end' : 'flex-start'
                         }}>
-                          {isUser ? 'You (Patient)' : 'MedGemma AI'}
+                          {isUser ? 'You' : 'Symptom assistant'}
                         </span>
 
                         {bubbleIsEmergency && (
@@ -635,7 +635,7 @@ export default function DoctorsPage() {
                   type="text"
                   value={followUpQuery}
                   onChange={(e) => setFollowUpQuery(e.target.value)}
-                  placeholder="Reply to MedGemma or provide more details..."
+                  placeholder="Reply or provide more details..."
                   disabled={aiLoading}
                   style={{
                     flex: 1,
@@ -691,7 +691,7 @@ export default function DoctorsPage() {
             <div style={{ marginTop: '36px' }}>
               <h3 style={{ fontSize: '16px', fontWeight: 800, color: '#0f172a', marginBottom: '20px', display: 'flex', alignItems: 'center', gap: '8px' }}>
                 <Sparkles size={16} color="#8b5cf6" />
-                <span>AI Recommended Specialist Matching ({recommendedDoctors.length})</span>
+                <span>Suggested specialists ({recommendedDoctors.length})</span>
                 {aiError && <span style={{ fontSize: '12px', color: '#ef4444', fontWeight: 500 }}>({aiError})</span>}
               </h3>
               
@@ -776,7 +776,7 @@ export default function DoctorsPage() {
                       }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: '4px', fontWeight: 700, marginBottom: '4px', fontSize: '12px' }}>
                           <Sparkles size={12} color="#7c3aed" />
-                          <span>AI MATCH RATIONALE</span>
+                          <span>WHY THIS MATCH</span>
                         </div>
                         {doc.reason}
                       </div>

--- a/apps/web/src/app/doctors/page.tsx
+++ b/apps/web/src/app/doctors/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, FormEvent, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { Show, UserButton } from '@clerk/nextjs'
-import { Search, Filter, User, Sparkles, AlertTriangle, Send, RefreshCw, X, ArrowRight, ShieldCheck, HeartPulse } from 'lucide-react'
+import { Search, Filter, User, Sparkles, AlertTriangle, Send, RefreshCw, X, ArrowRight, ShieldCheck, HeartPulse, Info } from 'lucide-react'
 import { useAiRecommendation, ChatMessage } from '../../lib/useAiRecommendation'
 import { SPECIALIZATIONS as SPECIALIZATION_OPTIONS } from '@lunasol/types'
 
@@ -186,6 +186,78 @@ const formatAiResponse = (content: string, isUser: boolean = false) => {
   return <div style={{ display: 'flex', flexDirection: 'column' }}>{elements}</div>
 }
 
+// Compact, accessible disclaimer indicator. Reveals the full safety/legal text
+// on hover and on keyboard focus. The text stays in the DOM (role="tooltip")
+// and is associated with the trigger via aria-describedby for screen readers.
+function DisclaimerTooltip() {
+  const [open, setOpen] = useState(false)
+  const tooltipId = 'ai-matcher-disclaimer'
+
+  return (
+    <div
+      style={{ position: 'relative', display: 'inline-flex' }}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+    >
+      <button
+        type="button"
+        aria-describedby={tooltipId}
+        aria-expanded={open}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '6px',
+          padding: '5px 10px',
+          borderRadius: '8px',
+          border: '1px solid rgba(245, 158, 11, 0.3)',
+          background: 'rgba(254, 243, 199, 0.55)',
+          color: '#92400e',
+          fontSize: '12.5px',
+          fontWeight: 600,
+          cursor: 'help',
+        }}
+      >
+        <ShieldCheck size={14} color="#d97706" style={{ flexShrink: 0 }} />
+        <span>Informational only</span>
+        <Info size={13} color="#d97706" style={{ flexShrink: 0 }} />
+      </button>
+
+      <div
+        id={tooltipId}
+        role="tooltip"
+        style={{
+          position: 'absolute',
+          top: 'calc(100% + 8px)',
+          right: 0,
+          zIndex: 20,
+          width: '320px',
+          maxWidth: '80vw',
+          background: 'rgba(254, 243, 199, 0.97)',
+          border: '1px solid rgba(245, 158, 11, 0.4)',
+          borderRadius: '12px',
+          padding: '14px 16px',
+          color: '#92400e',
+          fontSize: '13px',
+          lineHeight: '1.5',
+          boxShadow: '0 12px 28px -10px rgba(146, 64, 14, 0.25)',
+          opacity: open ? 1 : 0,
+          visibility: open ? 'visible' : 'hidden',
+          transform: open ? 'translateY(0)' : 'translateY(-4px)',
+          transition: 'opacity 0.15s ease, transform 0.15s ease',
+          pointerEvents: open ? 'auto' : 'none',
+          textAlign: 'left',
+          fontWeight: 400,
+        }}
+      >
+        <strong style={{ fontWeight: 700, display: 'block', marginBottom: '4px', fontSize: '13.5px' }}>AI Triage Advisor (Informational Only)</strong>
+        This tool utilizes clinical-grade language models to map described symptoms to specialties within our network. It <strong>does not diagnose illnesses, prescribe medications, or replace professional medical advice</strong>. If you are experiencing a severe, sudden, or life-threatening situation, please call emergency responders (e.g. 911) immediately.
+      </div>
+    </div>
+  )
+}
+
 export default function DoctorsPage() {
   const router = useRouter()
   const [doctors, setDoctors] = useState<Doctor[]>([])
@@ -340,6 +412,7 @@ export default function DoctorsPage() {
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px' }}>
                 <Sparkles size={20} color="#6366f1" style={{ filter: 'drop-shadow(0 0 6px rgba(99, 102, 241, 0.4))' }} />
                 <h2 style={{ fontSize: '22px', fontWeight: 800, color: '#0f172a', margin: 0, letterSpacing: '-0.5px' }}>Find the right specialist</h2>
+                <DisclaimerTooltip />
               </div>
               <p style={{ fontSize: '14px', color: '#475569', margin: 0 }}>Describe your symptoms and we&apos;ll suggest the right specialties.</p>
             </div>
@@ -368,27 +441,6 @@ export default function DoctorsPage() {
                 <span>Clear Analysis</span>
               </button>
             )}
-          </div>
-
-          {/* 1. Amber Disclaimer Banner (Required Guardrail) */}
-          <div style={{
-            background: 'rgba(254, 243, 199, 0.55)',
-            border: '1px solid rgba(245, 158, 11, 0.3)',
-            backdropFilter: 'blur(8px)',
-            borderRadius: '16px',
-            padding: '16px 20px',
-            display: 'flex',
-            gap: '14px',
-            color: '#92400e',
-            fontSize: '13.5px',
-            lineHeight: '1.5',
-            marginBottom: '24px'
-          }}>
-            <ShieldCheck size={20} color="#d97706" style={{ flexShrink: 0, marginTop: '2px' }} />
-            <div>
-              <strong style={{ fontWeight: 700, display: 'block', marginBottom: '2px', fontSize: '14px' }}>AI Triage Advisor (Informational Only)</strong>
-              This tool utilizes clinical-grade language models to map described symptoms to specialties within our network. It <strong>does not diagnose illnesses, prescribe medications, or replace professional medical advice</strong>. If you are experiencing a severe, sudden, or life-threatening situation, please call emergency responders (e.g. 911) immediately.
-            </div>
           </div>
 
           {/* 2. Symptom Input Area & Conversational Flow */}

--- a/apps/web/src/lib/time.ts
+++ b/apps/web/src/lib/time.ts
@@ -1,0 +1,57 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * Format the time remaining until an appointment's absolute UTC start instant.
+ *
+ * Pure and timezone-agnostic: it compares two absolute instants (epoch ms), so
+ * it stays consistent with browser-local `toLocaleTimeString` rendering — both
+ * derive from the same underlying UTC instant.
+ *
+ * @param startTimeIso ISO 8601 timestamp of the appointment start.
+ * @param now Epoch ms to compare against; defaults to `Date.now()`.
+ * @returns A short human label, or `null` when there's nothing to show.
+ *   - `null` when the start time is invalid or already past (more than a moment ago)
+ *   - `"starting now"` when within the start instant (<= 0)
+ *   - `"in 45m"` when under an hour away
+ *   - `"in 2h 15m"` when under a day away
+ *   - `"in 3d 4h"` when a day or more away
+ */
+export function formatTimeRemaining(startTimeIso: string, now?: number): string | null {
+  const start = new Date(startTimeIso).getTime()
+  if (Number.isNaN(start)) return null
+
+  const diffMs = start - (now ?? Date.now())
+
+  if (diffMs <= 0) {
+    // Within a short grace window of the start, surface "starting now".
+    // Past that, the appointment is effectively underway/over — hide it.
+    return diffMs > -60_000 ? 'starting now' : null
+  }
+
+  const totalMinutes = Math.floor(diffMs / 60_000)
+  const minutes = totalMinutes % 60
+  const totalHours = Math.floor(totalMinutes / 60)
+  const hours = totalHours % 24
+  const days = Math.floor(totalHours / 24)
+
+  if (days >= 1) return `in ${days}d ${hours}h`
+  if (totalHours >= 1) return `in ${totalHours}h ${minutes}m`
+  return `in ${totalMinutes}m`
+}
+
+/**
+ * Returns a `Date.now()` value that ticks every `intervalMs` (default 1 minute),
+ * so countdowns on a long-open page don't go stale. Cleans up on unmount.
+ */
+export function useNow(intervalMs = 60_000): number {
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs)
+    return () => clearInterval(id)
+  }, [intervalMs])
+
+  return now
+}

--- a/packages/types/src/appointment.ts
+++ b/packages/types/src/appointment.ts
@@ -1,3 +1,5 @@
+import type { AvailabilitySlot } from './doctor'
+
 export const AppointmentStatus = {
   PENDING: 'PENDING',
   CONFIRMED: 'CONFIRMED',
@@ -11,7 +13,10 @@ export interface Appointment {
   id: string
   patientId: string
   doctorId: string
-  slotId: string
+  /** Null for instant (on-demand) appointments, which have no pre-booked slot. */
+  slotId?: string | null
+  slot?: AvailabilitySlot | null
+  isInstant: boolean
   status: AppointmentStatus
   livekitRoom?: string
   createdAt: string

--- a/packages/types/src/doctor.ts
+++ b/packages/types/src/doctor.ts
@@ -6,6 +6,8 @@ export interface DoctorProfile {
   specialization: string
   profilePictureUrl?: string
   contactDetails?: string
+  /** Whether the doctor is currently accepting instant (on-demand) consultations. */
+  acceptingInstant?: boolean
 }
 
 export interface AvailabilitySlot {


### PR DESCRIPTION
## Release: `main` → `prod`

Promotes the current `main` (20 commits ahead) to production. Bundles the recently merged feature/fix PRs.

### Included
- **#69** Live time-remaining countdown on patient & doctor appointment cards (TZ-correct).
- **#70** AI doctor-matcher UX cleanup: de-buzzworded copy, disclaimer collapsed into an accessible tooltip, chat hidden when the AI service is down.
- **#71** Instant (on-demand) appointments — lean MVP: `acceptingInstant` doctor toggle, slotless instant appointments (nullable `slotId` + `isInstant`), `POST /api/appointments/instant`, immediate room join; appointment UI null-safe for instant appts.
- **#73** Sign-up fix: custom Clerk flow rewritten on the stable `@clerk/nextjs/legacy` hook (resolves "No sign up attempt was found").
- **#67** Navbar auth consistency (show profile instead of sign-in when logged in).

Scope: 22 files changed, +588 / −127.

### ⚠️ Pre-merge / deploy checklist
- [x] **DB migration** — #71 adds `instant_appointments` (new columns + `slotId` made nullable). The migration was hand-written and **not yet applied**; run `prisma migrate deploy` against the prod DB as part of the release.
- [x] Verify prod env vars (Clerk keys, `DATABASE_URL`, LiveKit) are set.
- [x] Smoke-test sign-up, instant consult, and a scheduled appointment after deploy.

### Deferred (tracked separately)
Instant-appointment hardening — auto-timeout, explicit decline, concurrency lock — is out of this release.
