### PR TITLE
fix(web): add clerk-captcha mount point to custom sign-up

### DIFF
--- a/apps/web/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/apps/web/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -134,6 +134,11 @@ export default function SignUpPage() {
               </select>
             </div>
 
+            {/* Clerk mounts its Smart CAPTCHA widget here. Required for custom
+                sign-up flows when Bot sign-up protection is enabled (prod);
+                without it prepareEmailAddressVerification fails with a 400. */}
+            <div id="clerk-captcha" />
+
             <button
               type="submit"
               disabled={loading}


### PR DESCRIPTION
## Problem

Sign-up fails on **production** with:

> We were unable to complete a GET request for this Client. No sign up attempt was found. Please try again.

## Root cause

The custom sign-up flow calls `prepareEmailAddressVerification` but renders no DOM node for Clerk's Smart CAPTCHA widget. The production Clerk instance has **Bot sign-up protection** enabled, so Clerk cannot obtain a CAPTCHA token and rejects `POST /v1/client/sign_ups/.../prepare_verification` with a **400**. The SDK surfaces this as the misleading "No sign up attempt was found."

Network trace when reproducing:

| Request | Result |
|---|---|
| `POST /v1/client/sign_ups` | 200 ✅ |
| `POST .../prepare_verification` | 400 ❌ |

Console confirms: *"Cannot initialize Smart CAPTCHA widget because the `clerk-captcha` DOM element was not found."*

This only reproduces on prod because dev Clerk instances don't enforce the CAPTCHA — which is why the earlier stable-hook fix (#72) didn't catch it.

## Fix

Add the documented `<div id="clerk-captcha" />` placeholder inside the create form so Clerk can mount the widget (Smart CAPTCHA stays invisible unless a bot is suspected).

Ref: https://clerk.com/docs/guides/development/custom-flows/authentication/bot-sign-up-protection

## Testing

Reproduced the 400 live on prod via browser automation. After this change Clerk has a mount point for the widget; recommend a manual end-to-end sign-up on the deployed build to confirm the verification email is sent.