### PR TITLE
feat(web): consultation note templates + notes during live session

### DIFF
--- a/apps/web/src/app/dashboard/doctor/appointments/[id]/ConsultationPanel.tsx
+++ b/apps/web/src/app/dashboard/doctor/appointments/[id]/ConsultationPanel.tsx
@@ -101,15 +101,19 @@ export default function ConsultationPanel({ appointmentId, embedded = false }: {
   return (
     <div
       style={
+        // Embedded (in the live-session drawer): no card chrome — the drawer
+        // supplies the frame and the "Consultation notes" header.
         embedded
-          ? { background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '20px' }
+          ? { background: 'transparent' }
           : { background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '28px', marginTop: '20px' }
       }
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '16px' }}>
-        <FileText size={20} color="#059669" />
-        <h2 style={{ fontSize: embedded ? '16px' : '18px', fontWeight: 700, color: '#111827', margin: 0 }}>Consultation notes</h2>
-      </div>
+      {!embedded && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '16px' }}>
+          <FileText size={20} color="#059669" />
+          <h2 style={{ fontSize: '18px', fontWeight: 700, color: '#111827', margin: 0 }}>Consultation notes</h2>
+        </div>
+      )}
 
       <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '8px', marginBottom: '12px' }}>
         <span style={{ fontSize: '12px', fontWeight: 600, color: '#6b7280' }}>Templates:</span>
@@ -169,7 +173,7 @@ export default function ConsultationPanel({ appointmentId, embedded = false }: {
 
         {showRxForm && (
           <div style={{ background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '8px', padding: '16px' }}>
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px', marginBottom: '10px' }}>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '10px', marginBottom: '10px' }}>
               <Field label="Medication" value={rx.medicationName} onChange={(v) => setRx({ ...rx, medicationName: v })} />
               <Field label="Dosage" value={rx.dosage} onChange={(v) => setRx({ ...rx, dosage: v })} />
               <Field label="Frequency" value={rx.frequency} onChange={(v) => setRx({ ...rx, frequency: v })} />

--- a/apps/web/src/app/dashboard/doctor/appointments/[id]/ConsultationPanel.tsx
+++ b/apps/web/src/app/dashboard/doctor/appointments/[id]/ConsultationPanel.tsx
@@ -22,7 +22,15 @@ interface ConsultationRecord {
 
 const EMPTY_RX = { medicationName: '', dosage: '', frequency: '', duration: '', notes: '' }
 
-export default function ConsultationPanel({ appointmentId }: { appointmentId: string }) {
+/** Quick-start templates for common consultation note structures (issue #79). */
+const NOTE_TEMPLATES: { label: string; body: string }[] = [
+  { label: 'General', body: 'Chief complaint:\n\nObservations:\n\nAssessment:\n\nPlan:\n' },
+  { label: 'Follow-up', body: 'Progress since last visit:\n\nCurrent status:\n\nPlan:\n' },
+  { label: 'Medication review', body: 'Current medications:\n\nAdherence:\n\nChanges:\n' },
+  { label: 'Referral', body: 'Reason for referral:\n\nReferred to:\n\nNotes:\n' },
+]
+
+export default function ConsultationPanel({ appointmentId, embedded = false }: { appointmentId: string; embedded?: boolean }) {
   const { getToken } = useAuth()
   const [record, setRecord] = useState<ConsultationRecord | null>(null)
   const [notes, setNotes] = useState('')
@@ -62,6 +70,10 @@ export default function ConsultationPanel({ appointmentId }: { appointmentId: st
     }
   }
 
+  function applyTemplate(body: string) {
+    setNotes((prev) => (prev.trim() ? prev.replace(/\s*$/, '') + '\n\n' + body : body))
+  }
+
   async function addPrescription() {
     if (!rx.medicationName.trim()) {
       alert('Medication name is required.')
@@ -87,10 +99,30 @@ export default function ConsultationPanel({ appointmentId }: { appointmentId: st
   }
 
   return (
-    <div style={{ background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '28px', marginTop: '20px' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '20px' }}>
+    <div
+      style={
+        embedded
+          ? { background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '20px' }
+          : { background: '#ffffff', border: '1px solid #e5e7eb', borderRadius: '12px', padding: '28px', marginTop: '20px' }
+      }
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '16px' }}>
         <FileText size={20} color="#059669" />
-        <h2 style={{ fontSize: '18px', fontWeight: 700, color: '#111827', margin: 0 }}>Consultation notes</h2>
+        <h2 style={{ fontSize: embedded ? '16px' : '18px', fontWeight: 700, color: '#111827', margin: 0 }}>Consultation notes</h2>
+      </div>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '8px', marginBottom: '12px' }}>
+        <span style={{ fontSize: '12px', fontWeight: 600, color: '#6b7280' }}>Templates:</span>
+        {NOTE_TEMPLATES.map((t) => (
+          <button
+            key={t.label}
+            type="button"
+            onClick={() => applyTemplate(t.body)}
+            style={{ padding: '4px 10px', background: '#f3f4f6', border: '1px solid #e5e7eb', borderRadius: '999px', fontSize: '12px', fontWeight: 600, color: '#374151', cursor: 'pointer' }}
+          >
+            {t.label}
+          </button>
+        ))}
       </div>
 
       <textarea

--- a/apps/web/src/app/dashboard/doctor/appointments/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/doctor/appointments/[id]/page.tsx
@@ -73,7 +73,15 @@ export default function DoctorAppointmentDetailPage() {
 
   if (inSession && appt) {
     // Re-fetch on leave so a status change (e.g. completed) is reflected.
-    return <ConsultationSession appointmentId={appt.id} onLeave={() => { setInSession(false); load() }} />
+    // The notes/prescription panel rides along in a side drawer so the doctor
+    // can write during the call (issue #87).
+    return (
+      <ConsultationSession
+        appointmentId={appt.id}
+        onLeave={() => { setInSession(false); load() }}
+        sidePanel={<ConsultationPanel appointmentId={appt.id} embedded />}
+      />
+    )
   }
 
   const isInstant = !!appt?.isInstant || (!!appt && !appt.slot)

--- a/apps/web/src/components/ConsultationSession.tsx
+++ b/apps/web/src/components/ConsultationSession.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useAuth } from '@clerk/nextjs'
 import { LiveKitRoom, VideoConference } from '@livekit/components-react'
 import '@livekit/components-styles'
+import { NotebookPen, X } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 
 interface ConsultationSessionProps {
@@ -11,17 +12,32 @@ interface ConsultationSessionProps {
   /** Called when the participant disconnects / leaves the room. */
   onLeave: () => void
   /**
-   * Optional content rendered in a collapsible drawer next to the video (e.g.
+   * Optional content rendered in a collapsible panel next to the video (e.g.
    * the doctor's notes/prescription panel). When omitted, the video fills the
    * screen as before — so the patient side is unchanged.
    */
   sidePanel?: React.ReactNode
 }
 
+/** True when the viewport is too narrow to show video + drawer side by side. */
+function useIsNarrow(maxWidth = 820) {
+  const [narrow, setNarrow] = useState(false)
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${maxWidth}px)`)
+    const update = () => setNarrow(mq.matches)
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [maxWidth])
+  return narrow
+}
+
 /**
  * Full-screen LiveKit consultation room. Fetches a short-lived token for the
- * given appointment, then renders the native LiveKit video UI (which includes
- * the ControlBar — mute, camera toggle, leave). No iframe.
+ * given appointment, then renders the LiveKit video UI (ControlBar — mute,
+ * camera toggle, leave) under a light theme. An optional `sidePanel` rides
+ * along in a collapsible drawer (side-by-side on desktop, full overlay on
+ * narrow screens).
  */
 export default function ConsultationSession({ appointmentId, onLeave, sidePanel }: ConsultationSessionProps) {
   const { getToken } = useAuth()
@@ -29,6 +45,7 @@ export default function ConsultationSession({ appointmentId, onLeave, sidePanel 
   const [serverUrl, setServerUrl] = useState<string>()
   const [error, setError] = useState<string>()
   const [panelOpen, setPanelOpen] = useState(true)
+  const narrow = useIsNarrow()
 
   useEffect(() => {
     let cancelled = false
@@ -53,8 +70,8 @@ export default function ConsultationSession({ appointmentId, onLeave, sidePanel 
 
   if (error) {
     return (
-      <div style={overlayStyle}>
-        <div style={{ textAlign: 'center', color: '#fff' }}>
+      <div style={messageOverlayStyle}>
+        <div style={{ textAlign: 'center', color: '#111827' }}>
           <p style={{ marginBottom: '16px' }}>{error}</p>
           <button onClick={onLeave} style={leaveButtonStyle}>
             Back to appointment
@@ -66,14 +83,16 @@ export default function ConsultationSession({ appointmentId, onLeave, sidePanel 
 
   if (!token || !serverUrl) {
     return (
-      <div style={overlayStyle}>
-        <p style={{ color: '#fff' }}>Connecting to the consultation…</p>
+      <div style={messageOverlayStyle}>
+        <p style={{ color: '#6b7280' }}>Connecting to the consultation…</p>
       </div>
     )
   }
 
+  const showDrawer = !!sidePanel && panelOpen
+
   return (
-    <div style={{ position: 'fixed', inset: 0, zIndex: 50, display: 'flex', background: '#111827' }}>
+    <div style={{ position: 'fixed', inset: 0, zIndex: 50, display: 'flex', background: '#f9fafb' }}>
       <div style={{ flex: 1, minWidth: 0, height: '100%', position: 'relative' }}>
         <LiveKitRoom
           token={token}
@@ -81,62 +100,96 @@ export default function ConsultationSession({ appointmentId, onLeave, sidePanel 
           connect
           data-lk-theme="default"
           onDisconnected={onLeave}
-          style={{ height: '100%' }}
+          style={{ height: '100%', ...lightThemeVars }}
         >
           <VideoConference />
         </LiveKitRoom>
         {sidePanel && !panelOpen && (
           <button onClick={() => setPanelOpen(true)} style={notesTabStyle}>
-            📝 Notes
+            <NotebookPen size={16} /> Notes
           </button>
         )}
       </div>
-      {sidePanel && panelOpen && (
-        <aside style={drawerStyle}>
+
+      {showDrawer && (
+        <aside style={narrow ? drawerOverlayStyle : drawerStyle}>
           <div style={drawerHeaderStyle}>
-            <span style={{ fontSize: '13px', fontWeight: 700, color: '#374151', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-              Consultation
+            <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '15px', fontWeight: 700, color: '#111827' }}>
+              <NotebookPen size={17} color="#059669" /> Consultation notes
             </span>
-            <button onClick={() => setPanelOpen(false)} style={drawerHideButtonStyle}>
-              Hide
+            <button onClick={() => setPanelOpen(false)} style={drawerHideButtonStyle} aria-label="Hide notes panel">
+              <X size={15} /> {narrow ? null : 'Hide'}
             </button>
           </div>
-          <div style={{ flex: 1, overflowY: 'auto', padding: '16px' }}>{sidePanel}</div>
+          <div style={{ flex: 1, overflowY: 'auto', padding: '16px', WebkitOverflowScrolling: 'touch' }}>{sidePanel}</div>
         </aside>
       )}
     </div>
   )
 }
 
-const overlayStyle: React.CSSProperties = {
+/**
+ * Inline overrides that flip LiveKit's default (dark) theme to a light palette
+ * matching the app. Set on the room element, these beat the stylesheet's
+ * `[data-lk-theme="default"]` rules. The bgN ladder goes light→mid-gray; the
+ * accent uses the app's green instead of LiveKit blue.
+ */
+const lightThemeVars = {
+  '--lk-bg': '#ffffff',
+  '--lk-bg2': '#f3f4f6',
+  '--lk-bg3': '#e5e7eb',
+  '--lk-bg4': '#d1d5db',
+  '--lk-bg5': '#9ca3af',
+  '--lk-fg': '#111827',
+  '--lk-fg2': '#1f2937',
+  '--lk-fg3': '#374151',
+  '--lk-fg4': '#4b5563',
+  '--lk-fg5': '#6b7280',
+  '--lk-border-color': 'rgba(0, 0, 0, 0.08)',
+  '--lk-accent-bg': '#10b981',
+  '--lk-accent-fg': '#ffffff',
+} as React.CSSProperties
+
+const messageOverlayStyle: React.CSSProperties = {
   position: 'fixed',
   inset: 0,
   zIndex: 50,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  background: '#111827',
+  background: '#f9fafb',
 }
 
 const leaveButtonStyle: React.CSSProperties = {
   padding: '10px 20px',
-  background: '#ffffff',
+  background: '#111827',
   border: 'none',
   borderRadius: '8px',
   fontSize: '14px',
   fontWeight: 600,
-  color: '#111827',
+  color: '#ffffff',
   cursor: 'pointer',
 }
 
 const drawerStyle: React.CSSProperties = {
-  width: '400px',
-  maxWidth: '90vw',
+  width: 'clamp(320px, 32vw, 440px)',
   height: '100%',
   display: 'flex',
   flexDirection: 'column',
-  background: '#f3f4f6',
+  background: '#ffffff',
   borderLeft: '1px solid #e5e7eb',
+  boxShadow: '-8px 0 24px rgba(0, 0, 0, 0.06)',
+}
+
+const drawerOverlayStyle: React.CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  zIndex: 52,
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  background: '#ffffff',
 }
 
 const drawerHeaderStyle: React.CSSProperties = {
@@ -146,9 +199,13 @@ const drawerHeaderStyle: React.CSSProperties = {
   padding: '14px 16px',
   borderBottom: '1px solid #e5e7eb',
   background: '#ffffff',
+  flexShrink: 0,
 }
 
 const drawerHideButtonStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
   padding: '6px 12px',
   background: 'none',
   border: '1px solid #d1d5db',
@@ -163,14 +220,17 @@ const notesTabStyle: React.CSSProperties = {
   position: 'absolute',
   top: '16px',
   right: '16px',
-  padding: '8px 14px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  padding: '9px 14px',
   background: '#ffffff',
-  border: 'none',
-  borderRadius: '8px',
+  border: '1px solid #e5e7eb',
+  borderRadius: '10px',
   fontSize: '13px',
   fontWeight: 600,
   color: '#111827',
   cursor: 'pointer',
-  boxShadow: '0 2px 8px rgba(0,0,0,0.25)',
+  boxShadow: '0 2px 10px rgba(0, 0, 0, 0.12)',
   zIndex: 51,
 }

--- a/apps/web/src/components/ConsultationSession.tsx
+++ b/apps/web/src/components/ConsultationSession.tsx
@@ -10,6 +10,12 @@ interface ConsultationSessionProps {
   appointmentId: string
   /** Called when the participant disconnects / leaves the room. */
   onLeave: () => void
+  /**
+   * Optional content rendered in a collapsible drawer next to the video (e.g.
+   * the doctor's notes/prescription panel). When omitted, the video fills the
+   * screen as before — so the patient side is unchanged.
+   */
+  sidePanel?: React.ReactNode
 }
 
 /**
@@ -17,11 +23,12 @@ interface ConsultationSessionProps {
  * given appointment, then renders the native LiveKit video UI (which includes
  * the ControlBar — mute, camera toggle, leave). No iframe.
  */
-export default function ConsultationSession({ appointmentId, onLeave }: ConsultationSessionProps) {
+export default function ConsultationSession({ appointmentId, onLeave, sidePanel }: ConsultationSessionProps) {
   const { getToken } = useAuth()
   const [token, setToken] = useState<string>()
   const [serverUrl, setServerUrl] = useState<string>()
   const [error, setError] = useState<string>()
+  const [panelOpen, setPanelOpen] = useState(true)
 
   useEffect(() => {
     let cancelled = false
@@ -66,17 +73,37 @@ export default function ConsultationSession({ appointmentId, onLeave }: Consulta
   }
 
   return (
-    <div style={{ position: 'fixed', inset: 0, zIndex: 50 }}>
-      <LiveKitRoom
-        token={token}
-        serverUrl={serverUrl}
-        connect
-        data-lk-theme="default"
-        onDisconnected={onLeave}
-        style={{ height: '100%' }}
-      >
-        <VideoConference />
-      </LiveKitRoom>
+    <div style={{ position: 'fixed', inset: 0, zIndex: 50, display: 'flex', background: '#111827' }}>
+      <div style={{ flex: 1, minWidth: 0, height: '100%', position: 'relative' }}>
+        <LiveKitRoom
+          token={token}
+          serverUrl={serverUrl}
+          connect
+          data-lk-theme="default"
+          onDisconnected={onLeave}
+          style={{ height: '100%' }}
+        >
+          <VideoConference />
+        </LiveKitRoom>
+        {sidePanel && !panelOpen && (
+          <button onClick={() => setPanelOpen(true)} style={notesTabStyle}>
+            📝 Notes
+          </button>
+        )}
+      </div>
+      {sidePanel && panelOpen && (
+        <aside style={drawerStyle}>
+          <div style={drawerHeaderStyle}>
+            <span style={{ fontSize: '13px', fontWeight: 700, color: '#374151', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+              Consultation
+            </span>
+            <button onClick={() => setPanelOpen(false)} style={drawerHideButtonStyle}>
+              Hide
+            </button>
+          </div>
+          <div style={{ flex: 1, overflowY: 'auto', padding: '16px' }}>{sidePanel}</div>
+        </aside>
+      )}
     </div>
   )
 }
@@ -100,4 +127,50 @@ const leaveButtonStyle: React.CSSProperties = {
   fontWeight: 600,
   color: '#111827',
   cursor: 'pointer',
+}
+
+const drawerStyle: React.CSSProperties = {
+  width: '400px',
+  maxWidth: '90vw',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  background: '#f3f4f6',
+  borderLeft: '1px solid #e5e7eb',
+}
+
+const drawerHeaderStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '14px 16px',
+  borderBottom: '1px solid #e5e7eb',
+  background: '#ffffff',
+}
+
+const drawerHideButtonStyle: React.CSSProperties = {
+  padding: '6px 12px',
+  background: 'none',
+  border: '1px solid #d1d5db',
+  borderRadius: '8px',
+  fontSize: '13px',
+  fontWeight: 600,
+  color: '#374151',
+  cursor: 'pointer',
+}
+
+const notesTabStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: '16px',
+  right: '16px',
+  padding: '8px 14px',
+  background: '#ffffff',
+  border: 'none',
+  borderRadius: '8px',
+  fontSize: '13px',
+  fontWeight: 600,
+  color: '#111827',
+  cursor: 'pointer',
+  boxShadow: '0 2px 8px rgba(0,0,0,0.25)',
+  zIndex: 51,
 }


### PR DESCRIPTION
Implements two related consultation-notes enhancements from the #34 bonus backlog, plus a UI/theme pass on the live video session. Frontend only — no API or schema changes (the panel already drives `/appointments/:id/record` and `.../record/prescriptions`).

## #79 — Consultation note templates
Quick-start template chips (General, Follow-up, Medication review, Referral) above the notes textarea. Clicking one **appends** its structure to the current notes (non-destructive — never overwrites existing text).

## #87 — Take notes during the live video session
Previously the doctor page early-returned the full-screen video when in session, so the notes panel was unreachable until they left the call. Now:
- `ConsultationSession` accepts an optional `sidePanel` and renders it in a collapsible drawer beside the video.
- The doctor appointment page passes `<ConsultationPanel embedded />`, so notes + prescriptions can be written mid-call.
- Patient side is unchanged (no `sidePanel` → video still fills the screen).

## UI / theme polish (follow-up to review feedback)
- **Light LiveKit theme:** override the real `--lk-*` CSS variables (read from `@livekit/components-styles` default theme) inline on the room element — dark `#111→#444` background ladder → light `#fff→#9ca3af`, text inverts to dark, and the accent uses the app's green (`#10b981`) instead of LiveKit blue. This also removes the abrupt dark/light seam against the drawer.
- **Responsive drawer:** `useIsNarrow` (matchMedia ≤820px) → side-by-side `clamp(320px, 32vw, 440px)` drawer on desktop, full-screen overlay on narrow screens.
- **De-cluttered panel:** when embedded, the panel drops its card chrome and its own "Consultation notes" header (the drawer supplies the single title) — no more card-in-a-box / doubled headings.
- **Consistency:** emoji "📝 Notes" tab → lucide `NotebookPen` icon; Hide uses `X`. Drawer gets a subtle left shadow for depth.
- **Narrow-column fix:** prescription form grid → `repeat(auto-fit, minmax(150px, 1fr))` so it collapses to one column when tight.

## Commits
1. `feat(web): consultation note templates + embeddable panel` (#79)
2. `feat(web): take notes during the live video session` (#87)
3. `feat(web): light LiveKit theme + responsive notes drawer`
4. `refactor(web): de-clutter embedded notes panel`

## Verify
1. `pnpm --filter @lunasol/web dev`.
2. As a doctor, open a CONFIRMED appointment → **Join session**.
3. Confirm: light-themed video; notes drawer beside it; type notes, click a template chip, add a prescription, save — all without leaving the call; Hide ↔ Notes toggle works.
4. Narrow the window (≤820px) → drawer becomes a full overlay.
5. As a patient, join the same session → full-screen video, no drawer.

`pnpm --filter @lunasol/web build` and `tsc --noEmit` pass.

> Note: types/build are verified, but the in-call layout has not been pixel-checked (the drawer only renders inside a live LiveKit room). A manual eyeball during a real session is recommended before merge.

Closes #79
Closes #87
