### PR TITLE
feat: suggest follow-up appointment from consultation notes

### DIFF
--- a/apps/api/src/appointments/appointments.controller.ts
+++ b/apps/api/src/appointments/appointments.controller.ts
@@ -62,4 +62,10 @@ export class AppointmentsController {
   complete(@Req() req: any, @Param('id') id: string) {
     return this.appointmentsService.complete(req.user.id, id)
   }
+
+  @Roles('doctor')
+  @Post(':id/suggest-follow-up')
+  suggestFollowUp(@Req() req: any, @Param('id') id: string) {
+    return this.appointmentsService.suggestFollowUp(req.user.id, id)
+  }
 }

--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -200,3 +200,84 @@ describe('AppointmentsService.getLivekitToken', () => {
     expect(payload.video.room).toBe(ROOM)
   })
 })
+
+describe('AppointmentsService.suggestFollowUp', () => {
+  let service: AppointmentsService
+  let prisma: {
+    appointment: { findUnique: jest.Mock }
+    user: { findUnique: jest.Mock }
+    notification: { create: jest.Mock }
+  }
+  let notifications: { emitToUser: jest.Mock }
+
+  const CLERK_ID = 'clerk_doctor_1'
+
+  const completedAppointment = {
+    id: 'appt-1',
+    doctorId: 'doc-1',
+    patientId: 'pat-1',
+    status: AppointmentStatus.COMPLETED,
+    doctor: { id: 'doc-1', name: 'Alice' },
+    patient: { id: 'pat-1', name: 'Bob', user: { id: 'user-pat-1' } },
+  }
+
+  beforeEach(() => {
+    prisma = {
+      appointment: { findUnique: jest.fn() },
+      user: { findUnique: jest.fn() },
+      notification: { create: jest.fn() },
+    }
+    notifications = { emitToUser: jest.fn() }
+    service = new AppointmentsService(prisma as any, notifications as any)
+  })
+
+  it('throws NotFound when the appointment does not exist', async () => {
+    prisma.user.findUnique.mockResolvedValue({ clerkId: CLERK_ID, doctor: { id: 'doc-1', name: 'Alice' } })
+    prisma.appointment.findUnique.mockResolvedValue(null)
+
+    await expect(service.suggestFollowUp(CLERK_ID, 'missing')).rejects.toBeInstanceOf(NotFoundException)
+  })
+
+  it('throws Forbidden when the appointment belongs to another doctor', async () => {
+    prisma.user.findUnique.mockResolvedValue({ clerkId: CLERK_ID, doctor: { id: 'doc-OTHER', name: 'Eve' } })
+    prisma.appointment.findUnique.mockResolvedValue(completedAppointment)
+
+    await expect(service.suggestFollowUp(CLERK_ID, 'appt-1')).rejects.toBeInstanceOf(ForbiddenException)
+  })
+
+  it('throws Conflict when the appointment is still pending', async () => {
+    prisma.user.findUnique.mockResolvedValue({ clerkId: CLERK_ID, doctor: { id: 'doc-1', name: 'Alice' } })
+    prisma.appointment.findUnique.mockResolvedValue({
+      ...completedAppointment,
+      status: AppointmentStatus.PENDING,
+    })
+
+    await expect(service.suggestFollowUp(CLERK_ID, 'appt-1')).rejects.toBeInstanceOf(ConflictException)
+  })
+
+  it('persists and emits a follow-up notification to the patient', async () => {
+    prisma.user.findUnique.mockResolvedValue({ clerkId: CLERK_ID, doctor: { id: 'doc-1', name: 'Alice' } })
+    prisma.appointment.findUnique.mockResolvedValue(completedAppointment)
+    prisma.notification.create.mockResolvedValue({
+      id: 'notif-1',
+      type: 'APPOINTMENT_FOLLOWUP_SUGGESTED',
+      message: 'msg',
+      createdAt: new Date(),
+    })
+
+    const result = await service.suggestFollowUp(CLERK_ID, 'appt-1')
+
+    expect(result).toEqual({ ok: true })
+    expect(prisma.notification.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        recipientId: 'user-pat-1',
+        type: 'APPOINTMENT_FOLLOWUP_SUGGESTED',
+      }),
+    })
+    expect(notifications.emitToUser).toHaveBeenCalledWith(
+      'user-pat-1',
+      'notification',
+      expect.objectContaining({ id: 'notif-1', type: 'APPOINTMENT_FOLLOWUP_SUGGESTED' }),
+    )
+  })
+})

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -294,6 +294,41 @@ export class AppointmentsService {
     return updated
   }
 
+  /**
+   * Suggest a follow-up appointment to the patient (issue #82). A doctor calls
+   * this from the consultation notes screen; it creates an actionable notification
+   * prompting the patient to rebook with the same doctor — no schema change, the
+   * patient follows the existing booking flow (`/doctors/:id`). The appointment
+   * must be confirmed or completed, mirroring when a consultation record exists.
+   */
+  async suggestFollowUp(clerkId: string, id: string) {
+    const { doctor } = await this.getDoctorProfile(clerkId)
+
+    const appointment = await this.prisma.appointment.findUnique({
+      where: { id },
+      include: { doctor: true, patient: { include: { user: true } } },
+    })
+
+    if (!appointment) throw new NotFoundException('Appointment not found')
+    if (appointment.doctorId !== doctor.id) throw new ForbiddenException('Not your appointment')
+    if (
+      appointment.status !== AppointmentStatus.CONFIRMED &&
+      appointment.status !== AppointmentStatus.COMPLETED
+    ) {
+      throw new ConflictException(
+        'A follow-up can only be suggested for a confirmed or completed appointment',
+      )
+    }
+
+    await this.createNotification(
+      appointment.patient.user.id,
+      'APPOINTMENT_FOLLOWUP_SUGGESTED',
+      `Dr. ${appointment.doctor.name} recommends a follow-up appointment. Book a new slot to continue your care.`,
+    )
+
+    return { ok: true }
+  }
+
   async complete(clerkId: string, id: string) {
     const { doctor } = await this.getDoctorProfile(clerkId)
 

--- a/apps/web/src/app/dashboard/doctor/appointments/[id]/ConsultationPanel.tsx
+++ b/apps/web/src/app/dashboard/doctor/appointments/[id]/ConsultationPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useAuth } from '@clerk/nextjs'
-import { Plus, FileText } from 'lucide-react'
+import { Plus, FileText, CalendarPlus } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 
 interface Prescription {
@@ -38,6 +38,8 @@ export default function ConsultationPanel({ appointmentId, embedded = false }: {
   const [rx, setRx] = useState({ ...EMPTY_RX })
   const [addingRx, setAddingRx] = useState(false)
   const [showRxForm, setShowRxForm] = useState(false)
+  const [suggestingFollowUp, setSuggestingFollowUp] = useState(false)
+  const [followUpSent, setFollowUpSent] = useState(false)
 
   const load = useCallback(async () => {
     try {
@@ -72,6 +74,22 @@ export default function ConsultationPanel({ appointmentId, embedded = false }: {
 
   function applyTemplate(body: string) {
     setNotes((prev) => (prev.trim() ? prev.replace(/\s*$/, '') + '\n\n' + body : body))
+  }
+
+  async function suggestFollowUp() {
+    setSuggestingFollowUp(true)
+    try {
+      const token = await getToken()
+      await apiFetch(`/appointments/${appointmentId}/suggest-follow-up`, {
+        token: token || undefined,
+        method: 'POST',
+      })
+      setFollowUpSent(true)
+    } catch (err: any) {
+      alert(err.message || 'Failed to suggest a follow-up.')
+    } finally {
+      setSuggestingFollowUp(false)
+    }
   }
 
   async function addPrescription() {
@@ -200,6 +218,28 @@ export default function ConsultationPanel({ appointmentId, embedded = false }: {
 
         {!record?.prescriptions.length && !showRxForm && (
           <p style={{ fontSize: '14px', color: '#9ca3af', margin: 0 }}>No prescriptions added.</p>
+        )}
+      </div>
+
+      <div style={{ marginTop: '28px', paddingTop: '24px', borderTop: '1px solid #f3f4f6' }}>
+        <h3 style={{ fontSize: '14px', fontWeight: 700, color: '#374151', textTransform: 'uppercase', letterSpacing: '0.05em', margin: '0 0 6px' }}>
+          Follow-up
+        </h3>
+        <p style={{ fontSize: '14px', color: '#6b7280', margin: '0 0 14px' }}>
+          Prompt the patient to book a follow-up appointment with you.
+        </p>
+        {followUpSent ? (
+          <p style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px', fontWeight: 600, color: '#059669', margin: 0 }}>
+            <CalendarPlus size={16} /> Follow-up suggestion sent to the patient.
+          </p>
+        ) : (
+          <button
+            onClick={suggestFollowUp}
+            disabled={suggestingFollowUp}
+            style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '10px 18px', background: '#10b981', border: 'none', borderRadius: '8px', fontSize: '14px', fontWeight: 600, color: '#ffffff', cursor: suggestingFollowUp ? 'default' : 'pointer', opacity: suggestingFollowUp ? 0.7 : 1 }}
+          >
+            <CalendarPlus size={16} /> {suggestingFollowUp ? 'Sending...' : 'Suggest follow-up'}
+          </button>
         )}
       </div>
     </div>

--- a/apps/web/src/components/NotificationBell.tsx
+++ b/apps/web/src/components/NotificationBell.tsx
@@ -28,7 +28,11 @@ export default function NotificationBell() {
   async function handleClick(id: string, type: string) {
     await markRead(id)
     setOpen(false)
-    if (type.startsWith('APPOINTMENT')) {
+    // A follow-up suggestion (issue #82) deep-links the patient into the
+    // booking flow so they can rebook right away.
+    if (type === 'APPOINTMENT_FOLLOWUP_SUGGESTED') {
+      router.push('/doctors')
+    } else if (type.startsWith('APPOINTMENT')) {
       router.push(
         role === 'doctor'
           ? '/dashboard/doctor'


### PR DESCRIPTION
## What

Lets a doctor suggest a follow-up appointment directly from the consultation notes screen, closing the loop and driving rebooking. Closes #82.

## Approach

Notification-with-booking-link, **no schema change**:

- **API:** New doctor-only `POST /api/appointments/:id/suggest-follow-up`. `AppointmentsService.suggestFollowUp` validates the doctor owns the appointment and it's `CONFIRMED`/`COMPLETED`, then creates a persisted `Notification` (type `APPOINTMENT_FOLLOWUP_SUGGESTED`) for the patient and emits it over the existing Socket.IO gateway via `createNotification` — same path as confirm/cancel/reschedule. The message names the doctor and prompts a rebook.
- **Web:** Added a "Suggest follow-up" CTA (with a sent-confirmation state) to `ConsultationPanel.tsx`, calling the new endpoint via `apiFetch`. `NotificationBell` routes the new notification type to `/doctors` so clicking it drops the patient into the booking flow. (The `Notification` model has no link column and the issue scoped out schema changes, so deep-linking uses the existing type-based routing.)

## Files

- `apps/api/src/appointments/appointments.service.ts` — `suggestFollowUp`
- `apps/api/src/appointments/appointments.controller.ts` — route
- `apps/api/src/appointments/appointments.service.spec.ts` — 4 new specs
- `apps/web/src/app/dashboard/doctor/appointments/[id]/ConsultationPanel.tsx` — CTA
- `apps/web/src/components/NotificationBell.tsx` — notification routing

## Verification

- `tsc --noEmit` clean for both `apps/api` and `apps/web`
- `pnpm --filter @lunasol/api test`: 55/55 passing (incl. 4 new `suggestFollowUp` specs)
- `pnpm lint`: clean (only pre-existing `any` warnings; none in changed files)