### PR TITLE
feat: patient health dashboard with weight/height trends

### DIFF
--- a/apps/api/prisma/migrations/20260530170000_patient_metrics/migration.sql
+++ b/apps/api/prisma/migrations/20260530170000_patient_metrics/migration.sql
@@ -1,0 +1,19 @@
+-- Time-series snapshot of a patient's weight/height, captured on profile updates.
+-- Powers the patient health dashboard weight/height trends.
+
+-- CreateTable
+CREATE TABLE "PatientMetric" (
+    "id" TEXT NOT NULL,
+    "patientId" TEXT NOT NULL,
+    "weight" DOUBLE PRECISION NOT NULL,
+    "height" DOUBLE PRECISION NOT NULL,
+    "recordedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PatientMetric_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PatientMetric_patientId_recordedAt_idx" ON "PatientMetric"("patientId", "recordedAt");
+
+-- AddForeignKey
+ALTER TABLE "PatientMetric" ADD CONSTRAINT "PatientMetric_patientId_fkey" FOREIGN KEY ("patientId") REFERENCES "PatientProfile"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -66,6 +66,7 @@ model PatientProfile {
   appointments      Appointment[]
   conversations     Conversation[]
   symptomLogs       SymptomLog[]
+  metrics           PatientMetric[]
 }
 
 model DoctorProfile {
@@ -198,4 +199,19 @@ model SymptomLog {
   updatedAt   DateTime        @updatedAt
 
   @@index([patientId, loggedAt])
+}
+
+// ─── Patient Metrics ────────────────────────────────────────────────────────────
+// Time-series snapshot of a patient's weight/height, captured whenever the patient
+// updates those values on their profile. Powers the patient health dashboard trends.
+
+model PatientMetric {
+  id         String         @id @default(cuid())
+  patientId  String
+  patient    PatientProfile @relation(fields: [patientId], references: [id], onDelete: Cascade)
+  weight     Float
+  height     Float
+  recordedAt DateTime       @default(now())
+
+  @@index([patientId, recordedAt])
 }

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -142,6 +142,7 @@ async function main() {
 
   // ── 1. Clean slate (reverse FK order) ────────────────────────────────────
   console.log('  ✕ Clearing existing data …');
+  await prisma.patientMetric.deleteMany();
   await prisma.symptomLog.deleteMany();
   await prisma.notification.deleteMany();
   await prisma.prescription.deleteMany();
@@ -379,6 +380,33 @@ async function main() {
     symptomLogCount += entries.length;
   }
 
+  // ── 6c. Create patient metrics (weight/height time-series) ───────────────
+  console.log('  + Creating patient metrics …');
+
+  // A short trend per patient ending at their current profile weight/height,
+  // so the patient health dashboard has a sparkline to render.
+  let patientMetricCount = 0;
+  for (let i = 0; i < patientProfiles.length; i++) {
+    const profile = patientProfiles[i]!;
+    // Drift backwards from the current weight over the last few months.
+    const points = [
+      { recordedAt: pastDate(120, 9), weight: profile.weight + 4 },
+      { recordedAt: pastDate(90, 9), weight: profile.weight + 2.5 },
+      { recordedAt: pastDate(60, 9), weight: profile.weight + 1 },
+      { recordedAt: pastDate(30, 9), weight: profile.weight + 0.5 },
+      { recordedAt: pastDate(1, 9), weight: profile.weight },
+    ];
+    await prisma.patientMetric.createMany({
+      data: points.map((p) => ({
+        patientId: profile.id,
+        weight: Math.round(p.weight * 10) / 10,
+        height: profile.height,
+        recordedAt: p.recordedAt,
+      })),
+    });
+    patientMetricCount += points.length;
+  }
+
   // ── 7. Create notifications ──────────────────────────────────────────────
   console.log('  + Creating notifications …');
 
@@ -496,6 +524,7 @@ async function main() {
     prescriptions: await prisma.prescription.count(),
     notifications: await prisma.notification.count(),
     symptomLogs: await prisma.symptomLog.count(),
+    patientMetrics: await prisma.patientMetric.count(),
   };
 
   console.log('\n✅ Seed complete!');

--- a/apps/api/src/patients/patients.controller.ts
+++ b/apps/api/src/patients/patients.controller.ts
@@ -43,6 +43,11 @@ export class PatientsController implements OnModuleInit {
     return this.patientsService.getProfile(req.user.id)
   }
 
+  @Get('me/metrics')
+  async getMetrics(@Req() req: any) {
+    return this.patientsService.getMetrics(req.user.id)
+  }
+
   @Patch('me')
   async updateProfile(@Req() req: any, @Body() dto: UpdateProfileDto) {
     return this.patientsService.updateProfile(req.user.id, dto)

--- a/apps/api/src/patients/patients.service.spec.ts
+++ b/apps/api/src/patients/patients.service.spec.ts
@@ -1,0 +1,92 @@
+import { NotFoundException } from '@nestjs/common'
+import { PatientsService } from './patients.service'
+
+describe('PatientsService', () => {
+  let service: PatientsService
+  let prisma: {
+    user: { findUnique: jest.Mock }
+    patientProfile: { update: jest.Mock; create: jest.Mock }
+    patientMetric: { findMany: jest.Mock; create: jest.Mock }
+  }
+
+  const CLERK_ID = 'clerk_patient_1'
+  const PATIENT = {
+    id: 'pat-1',
+    userId: 'user-1',
+    name: 'Bob Patient',
+    birthday: new Date('1990-01-01'),
+    weight: 70,
+    height: 175,
+  }
+
+  beforeEach(() => {
+    prisma = {
+      user: { findUnique: jest.fn() },
+      patientProfile: { update: jest.fn(), create: jest.fn() },
+      patientMetric: { findMany: jest.fn(), create: jest.fn() },
+    }
+    process.env.CLERK_SECRET_KEY = 'sk_test_dummy'
+    service = new PatientsService(prisma as any)
+  })
+
+  describe('getMetrics', () => {
+    it('throws NotFound when the patient profile does not exist', async () => {
+      prisma.user.findUnique.mockResolvedValue(null)
+
+      await expect(service.getMetrics(CLERK_ID)).rejects.toBeInstanceOf(NotFoundException)
+    })
+
+    it('returns the patient metrics ordered oldest-first', async () => {
+      prisma.user.findUnique.mockResolvedValue({ clerkId: CLERK_ID, patient: PATIENT })
+      const rows = [
+        { id: 'm1', patientId: 'pat-1', weight: 72, height: 175, recordedAt: new Date() },
+      ]
+      prisma.patientMetric.findMany.mockResolvedValue(rows)
+
+      const result = await service.getMetrics(CLERK_ID)
+
+      expect(result).toBe(rows)
+      expect(prisma.patientMetric.findMany).toHaveBeenCalledWith({
+        where: { patientId: 'pat-1' },
+        orderBy: { recordedAt: 'asc' },
+      })
+    })
+  })
+
+  describe('updateProfile metric snapshotting', () => {
+    beforeEach(() => {
+      // ensurePatientRecord resolves to an existing user with a patient profile.
+      prisma.user.findUnique.mockResolvedValue({
+        id: 'user-1',
+        clerkId: CLERK_ID,
+        patient: PATIENT,
+      })
+    })
+
+    it('snapshots a metric row when weight changes', async () => {
+      prisma.patientProfile.update.mockResolvedValue({ ...PATIENT, weight: 68 })
+
+      await service.updateProfile(CLERK_ID, { weight: 68 } as any)
+
+      expect(prisma.patientMetric.create).toHaveBeenCalledWith({
+        data: { patientId: 'pat-1', weight: 68, height: 175 },
+      })
+    })
+
+    it('does not snapshot when weight/height are unchanged', async () => {
+      prisma.patientProfile.update.mockResolvedValue({ ...PATIENT })
+
+      await service.updateProfile(CLERK_ID, { name: 'New Name' } as any)
+
+      expect(prisma.patientMetric.create).not.toHaveBeenCalled()
+    })
+
+    it('does not snapshot when weight is set to the same value', async () => {
+      prisma.patientProfile.update.mockResolvedValue({ ...PATIENT })
+
+      await service.updateProfile(CLERK_ID, { weight: 70 } as any)
+
+      expect(prisma.patientMetric.create).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/api/src/patients/patients.service.ts
+++ b/apps/api/src/patients/patients.service.ts
@@ -64,6 +64,7 @@ export class PatientsService {
 
   async updateProfile(clerkId: string, dto: UpdateProfileDto) {
     const user = await this.ensurePatientRecord(clerkId)
+    const current = user.patient!
 
     const data: Record<string, any> = {}
     if (dto.name !== undefined) data.name = dto.name
@@ -75,12 +76,43 @@ export class PatientsService {
     if (dto.medicalHistory !== undefined) data.medicalHistory = dto.medicalHistory
 
     const updated = await this.prisma.patientProfile.update({
-      where: { id: user.patient!.id },
+      where: { id: current.id },
       data,
     })
 
+    // Snapshot a metric row whenever weight or height actually changes, so the
+    // patient health dashboard can plot the trend over time.
+    const weightChanged = dto.weight !== undefined && dto.weight !== current.weight
+    const heightChanged = dto.height !== undefined && dto.height !== current.height
+    if ((weightChanged || heightChanged) && updated.weight > 0 && updated.height > 0) {
+      await this.prisma.patientMetric.create({
+        data: {
+          patientId: updated.id,
+          weight: updated.weight,
+          height: updated.height,
+        },
+      })
+    }
+
     const profileComplete = updated.weight > 0 && updated.height > 0
     return { ...updated, profileComplete }
+  }
+
+  // Returns the requesting patient's weight/height history, oldest first.
+  async getMetrics(clerkId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { clerkId },
+      include: { patient: true },
+    })
+
+    if (!user?.patient) {
+      throw new NotFoundException('Patient profile not found')
+    }
+
+    return this.prisma.patientMetric.findMany({
+      where: { patientId: user.patient.id },
+      orderBy: { recordedAt: 'asc' },
+    })
   }
 
   async updatePicture(clerkId: string, filename: string) {

--- a/apps/web/src/app/dashboard/patient/HealthDashboard.tsx
+++ b/apps/web/src/app/dashboard/patient/HealthDashboard.tsx
@@ -1,0 +1,240 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useAuth } from '@clerk/nextjs'
+import { TrendingUp, CalendarClock, Scale, Ruler, Zap } from 'lucide-react'
+import type { PatientMetric } from '@lunasol/types'
+import { apiFetch } from '@/lib/api'
+import { formatTimeRemaining, useNow } from '@/lib/time'
+
+interface Appointment {
+  id: string
+  status: 'PENDING' | 'CONFIRMED' | 'CANCELLED' | 'COMPLETED'
+  isInstant: boolean
+  doctor: { id: string; name: string; specialization: string } | null
+  slot: { startTime: string; endTime: string } | null
+}
+
+const cardStyle: React.CSSProperties = {
+  background: '#ffffff',
+  border: '1px solid #e5e7eb',
+  borderRadius: '12px',
+  padding: '24px',
+  boxShadow: '0 1px 3px rgba(0, 0, 0, 0.02)',
+}
+
+/**
+ * Lightweight inline-SVG line chart of a metric series. No charting dependency —
+ * matches the repo's no-Tailwind, inline-style convention. Renders a smooth
+ * polyline with point markers, scaled to the data's own min/max.
+ */
+function Sparkline({
+  values,
+  color,
+  width = 520,
+  height = 120,
+}: {
+  values: number[]
+  color: string
+  width?: number
+  height?: number
+}) {
+  if (values.length === 0) return null
+
+  const pad = 12
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const span = max - min || 1
+  const innerW = width - pad * 2
+  const innerH = height - pad * 2
+
+  const points = values.map((v, i) => {
+    const x = values.length === 1 ? width / 2 : pad + (i / (values.length - 1)) * innerW
+    const y = pad + (1 - (v - min) / span) * innerH
+    return { x, y }
+  })
+
+  const line = points.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ')
+  const area = `${pad},${height - pad} ${line} ${width - pad},${height - pad}`
+
+  return (
+    <svg
+      width="100%"
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      style={{ display: 'block' }}
+      role="img"
+      aria-label="Trend chart"
+    >
+      <polygon points={area} fill={color} fillOpacity={0.08} />
+      <polyline points={line} fill="none" stroke={color} strokeWidth={2.5} strokeLinejoin="round" strokeLinecap="round" />
+      {points.map((p, i) => (
+        <circle key={i} cx={p.x} cy={p.y} r={3} fill="#ffffff" stroke={color} strokeWidth={2} />
+      ))}
+    </svg>
+  )
+}
+
+export default function HealthDashboard() {
+  const { getToken } = useAuth()
+  const now = useNow()
+  const [metrics, setMetrics] = useState<PatientMetric[]>([])
+  const [appointments, setAppointments] = useState<Appointment[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const token = await getToken()
+        const opts = { token: token || undefined }
+        const [m, a] = await Promise.all([
+          apiFetch('/patients/me/metrics', opts),
+          apiFetch('/appointments/mine', opts),
+        ])
+        if (!cancelled) {
+          setMetrics(m)
+          setAppointments(a)
+        }
+      } catch {
+        // Leave empty states in place on failure.
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [getToken])
+
+  // Soonest upcoming PENDING/CONFIRMED appointment. Instant appointments have
+  // slot === null; treat them as immediately upcoming so they sort first.
+  const nextAppt = appointments
+    .filter((a) => a.status === 'PENDING' || a.status === 'CONFIRMED')
+    .filter((a) => !a.slot || new Date(a.slot.startTime).getTime() > now - 60 * 60_000)
+    .sort((a, b) => {
+      const ta = a.slot ? new Date(a.slot.startTime).getTime() : 0
+      const tb = b.slot ? new Date(b.slot.startTime).getTime() : 0
+      return ta - tb
+    })[0]
+
+  const weights = metrics.map((m) => m.weight)
+  const latest = metrics[metrics.length - 1]
+  const first = metrics[0]
+  const weightDelta = latest && first ? latest.weight - first.weight : 0
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 2fr) minmax(0, 1fr)', gap: '24px', marginBottom: '40px' }}>
+      {/* Weight trend */}
+      <div style={cardStyle}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '16px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <div style={{ display: 'inline-flex', padding: '8px', background: '#eff6ff', borderRadius: '8px', color: '#2563eb' }}>
+              <TrendingUp size={20} />
+            </div>
+            <div>
+              <h3 style={{ fontSize: '16px', fontWeight: 600, margin: 0, color: '#111827' }}>Weight Trend</h3>
+              <p style={{ fontSize: '13px', color: '#6b7280', margin: '2px 0 0 0' }}>Over your recorded history</p>
+            </div>
+          </div>
+          {latest && (
+            <div style={{ textAlign: 'right' }}>
+              <div style={{ fontSize: '22px', fontWeight: 700, color: '#111827', lineHeight: 1 }}>
+                {latest.weight} <span style={{ fontSize: '13px', fontWeight: 500, color: '#6b7280' }}>kg</span>
+              </div>
+              {metrics.length > 1 && (
+                <div style={{ fontSize: '12px', fontWeight: 600, marginTop: '4px', color: weightDelta > 0 ? '#b91c1c' : weightDelta < 0 ? '#15803d' : '#6b7280' }}>
+                  {weightDelta > 0 ? '+' : ''}{weightDelta.toFixed(1)} kg
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {loading ? (
+          <p style={{ fontSize: '14px', color: '#9ca3af', margin: 0 }}>Loading…</p>
+        ) : metrics.length === 0 ? (
+          <p style={{ fontSize: '14px', color: '#6b7280', margin: 0, lineHeight: 1.5 }}>
+            No measurements yet. Update your weight and height on your{' '}
+            <a href="/dashboard/patient/profile" style={{ color: '#2563eb' }}>profile</a> to start tracking trends.
+          </p>
+        ) : (
+          <>
+            <Sparkline values={weights} color="#2563eb" />
+            <div style={{ display: 'flex', gap: '24px', marginTop: '16px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+                <Scale size={15} /> {weights.length} reading{weights.length === 1 ? '' : 's'}
+              </div>
+              {latest && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#6b7280' }}>
+                  <Ruler size={15} /> {latest.height} cm
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Next appointment summary */}
+      <div style={cardStyle}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '16px' }}>
+          <div style={{ display: 'inline-flex', padding: '8px', background: '#f0fdf4', borderRadius: '8px', color: '#16a34a' }}>
+            <CalendarClock size={20} />
+          </div>
+          <h3 style={{ fontSize: '16px', fontWeight: 600, margin: 0, color: '#111827' }}>Next Appointment</h3>
+        </div>
+
+        {loading ? (
+          <p style={{ fontSize: '14px', color: '#9ca3af', margin: 0 }}>Loading…</p>
+        ) : !nextAppt ? (
+          <div>
+            <p style={{ fontSize: '14px', color: '#6b7280', margin: '0 0 16px 0', lineHeight: 1.5 }}>
+              You have no upcoming appointments.
+            </p>
+            <a href="/doctors" style={{ display: 'inline-block', background: '#111827', color: '#ffffff', padding: '8px 16px', borderRadius: '8px', fontSize: '13px', fontWeight: 600, textDecoration: 'none' }}>
+              Book a Doctor
+            </a>
+          </div>
+        ) : (
+          <div>
+            <div style={{ fontSize: '15px', fontWeight: 600, color: '#111827', marginBottom: '4px' }}>
+              {nextAppt.doctor?.name ?? 'Your doctor'}
+            </div>
+            <div style={{ fontSize: '13px', color: '#6b7280', marginBottom: '12px' }}>
+              {nextAppt.doctor?.specialization ?? 'Consultation'}
+            </div>
+
+            <div style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', fontSize: '12px', fontWeight: 600, padding: '3px 10px', borderRadius: '12px', background: nextAppt.status === 'CONFIRMED' ? '#f0fdf4' : '#fef9c3', color: nextAppt.status === 'CONFIRMED' ? '#166534' : '#854d0e', marginBottom: '12px' }}>
+              {nextAppt.status}
+            </div>
+
+            {nextAppt.isInstant || !nextAppt.slot ? (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '13px', color: '#7c3aed', fontWeight: 600 }}>
+                <Zap size={15} /> Instant consultation
+              </div>
+            ) : (
+              <div style={{ fontSize: '13px', color: '#374151' }}>
+                {new Date(nextAppt.slot.startTime).toLocaleString([], {
+                  weekday: 'short',
+                  month: 'short',
+                  day: 'numeric',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+                {(() => {
+                  const rel = formatTimeRemaining(nextAppt.slot.startTime, now)
+                  return rel ? <span style={{ color: '#6b7280' }}> · {rel}</span> : null
+                })()}
+              </div>
+            )}
+
+            <a href="/dashboard/patient/appointments" style={{ display: 'inline-block', marginTop: '16px', fontSize: '13px', fontWeight: 600, color: '#2563eb', textDecoration: 'none' }}>
+              View all appointments →
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/dashboard/patient/page.tsx
+++ b/apps/web/src/app/dashboard/patient/page.tsx
@@ -2,6 +2,7 @@ import { UserButton } from '@clerk/nextjs'
 import { currentUser } from '@clerk/nextjs/server'
 import { Video, Bot, FolderOpen, Calendar, Activity } from 'lucide-react'
 import NotificationBell from '@/components/NotificationBell'
+import HealthDashboard from './HealthDashboard'
 
 export default async function PatientDashboard() {
   const user = await currentUser()
@@ -42,6 +43,9 @@ export default async function PatientDashboard() {
             All your health resources, virtual consultations, and medical records are synchronized and ready.
           </p>
         </div>
+
+        {/* Health Dashboard: weight/height trend + next-appointment summary */}
+        <HealthDashboard />
 
         {/* Quick Stats / Actions */}
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '24px', marginBottom: '40px' }}>

--- a/packages/types/src/patient.ts
+++ b/packages/types/src/patient.ts
@@ -10,3 +10,15 @@ export interface PatientProfile {
   address?: string
   medicalHistory?: string
 }
+
+/**
+ * Time-series snapshot of a patient's weight/height, captured whenever the
+ * patient updates those values on their profile. Powers the health dashboard.
+ */
+export interface PatientMetric {
+  id: string
+  patientId: string
+  weight: number
+  height: number
+  recordedAt: string
+}


### PR DESCRIPTION
## Summary
Gives patients a personal health dashboard on `dashboard/patient`: a weight/height trend chart plus a next-appointment summary card. Closes #74.

## What changed
- **Schema/migration:** new `PatientMetric` time-series model (`patientId`, `weight`, `height`, `recordedAt`, indexed on `(patientId, recordedAt)`, FK cascade from `PatientProfile`). Migration `20260530170000_patient_metrics`.
- **Seed:** clears `patientMetric` in reverse-FK order and seeds a 5-point weight trend per patient (20 rows); added to the final counts log.
- **Types:** added `PatientMetric` DTO to `@lunasol/types`.
- **API:** `PatientsService.updateProfile` now snapshots a `PatientMetric` row whenever weight or height actually changes. New `GET /patients/me/metrics` (`@Roles('patient')`) returns the requesting patient's history ordered by `recordedAt`. Added `patients.service.spec.ts`.
- **Web:** new `'use client'` `HealthDashboard.tsx` fetches `/patients/me/metrics` + `/appointments/mine` with the Clerk token via `apiFetch`, renders a **lightweight inline-SVG sparkline** (no charting dependency, matching the no-Tailwind inline-style convention) for the weight trend and a next-appointment summary (soonest upcoming PENDING/CONFIRMED, null-safe on `slot` so instant appointments render). Mounted from the patient dashboard server component.

## Approach notes
- Chart is hand-rolled inline SVG (polyline + area + point markers, auto-scaled) to avoid adding a dependency.
- Metrics are snapshotted at profile-update time in the patients module (which owns PatientProfile/PatientMetric); the appointment summary reuses the existing appointments API rather than querying the Appointment table cross-module.

## Verification
- `tsc --noEmit` clean for both `apps/api` and `apps/web`.
- `pnpm --filter @lunasol/api test` — 56 passed (incl. new spec).
- Migration applied and `prisma generate` run; seed re-runs successfully (patientMetrics: 20).
- `pnpm lint` — 0 errors (only pre-existing `any` warnings).