### PR TITLE
fix: graceful error handling across web, API, and AI service

### DIFF
--- a/apps/ai/src/main.py
+++ b/apps/ai/src/main.py
@@ -1,11 +1,15 @@
+import logging
 import os
 from contextlib import asynccontextmanager
-from fastapi import FastAPI
-from fastapi.responses import StreamingResponse
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from src.schemas import RecommendRequest
 from src.model import load_model, unload_model, get_model
 from src.triage import mock_recommendation_stream, real_recommendation_stream
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("lunasol.ai")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -14,6 +18,13 @@ async def lifespan(app: FastAPI):
     unload_model()
 
 app = FastAPI(title="LunaSol AI Recommendation Service", lifespan=lifespan)
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    # Log the real cause server-side; return a sanitized message to the client.
+    logger.exception("Unhandled error on %s %s", request.method, request.url.path)
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
 
 @app.post("/recommend")
 async def recommend(request: RecommendRequest):

--- a/apps/ai/src/triage.py
+++ b/apps/ai/src/triage.py
@@ -1,8 +1,11 @@
 import asyncio
 import json
+import logging
 from typing import List
 from src.schemas import ChatMessage, Doctor
 from src.utils import extract_recommendations
+
+logger = logging.getLogger("lunasol.ai")
 
 async def mock_recommendation_stream(messages: List[ChatMessage], doctors: List[Doctor]):
     try:
@@ -114,8 +117,9 @@ async def mock_recommendation_stream(messages: List[ChatMessage], doctors: List[
         # Emit structured data
         yield f"event: recommendations\ndata: {json.dumps(recommendations)}\n\n"
         yield "event: done\ndata: [DONE]\n\n"
-    except Exception as e:
-        yield f"event: error\ndata: {str(e)}\n\n"
+    except Exception:
+        logger.exception("recommendation stream failed")
+        yield "event: error\ndata: The recommendation service hit an error. Please try again.\n\n"
 
 async def real_recommendation_stream(messages: List[ChatMessage], doctors: List[Doctor], model):
     try:
@@ -210,5 +214,6 @@ async def real_recommendation_stream(messages: List[ChatMessage], doctors: List[
         
         yield "event: done\ndata: [DONE]\n\n"
         
-    except Exception as e:
-        yield f"event: error\ndata: {str(e)}\n\n"
+    except Exception:
+        logger.exception("recommendation stream failed")
+        yield "event: error\ndata: The recommendation service hit an error. Please try again.\n\n"

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common'
+import { APP_FILTER } from '@nestjs/core'
 import { ScheduleModule } from '@nestjs/schedule'
+import { AllExceptionsFilter } from './common/all-exceptions.filter'
 import { PrismaModule } from './prisma/prisma.module'
 import { AuthModule } from './auth/auth.module'
 import { PatientsModule } from './patients/patients.module'
@@ -14,6 +16,7 @@ import { RemindersModule } from './reminders/reminders.module'
 
 @Module({
   imports: [ScheduleModule.forRoot(), PrismaModule, AuthModule, PatientsModule, DoctorsModule, AppointmentsModule, ConsultationsModule, NotificationsModule, AiModule, ChatModule, SymptomLogsModule, RemindersModule],
+  providers: [{ provide: APP_FILTER, useClass: AllExceptionsFilter }],
 })
 export class AppModule {}
 

--- a/apps/api/src/common/all-exceptions.filter.spec.ts
+++ b/apps/api/src/common/all-exceptions.filter.spec.ts
@@ -1,0 +1,56 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common'
+import { AllExceptionsFilter } from './all-exceptions.filter'
+
+describe('AllExceptionsFilter', () => {
+  let filter: AllExceptionsFilter
+  let reply: jest.Mock
+
+  const host = (url = '/api/thing') =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({ url }),
+        getResponse: () => ({ __res: true }),
+      }),
+    }) as any
+
+  beforeEach(() => {
+    reply = jest.fn()
+    const httpAdapterHost = {
+      httpAdapter: { reply, getRequestUrl: (req: any) => req.url },
+    }
+    filter = new AllExceptionsFilter(httpAdapterHost as any)
+  })
+
+  it('preserves an HttpException status and message in a normalized body', () => {
+    filter.catch(new NotFoundException('Symptom log not found'), host('/api/symptom-logs/x'))
+
+    const [res, body, status] = reply.mock.calls[0]
+    expect(res).toEqual({ __res: true })
+    expect(status).toBe(404)
+    expect(body).toEqual(
+      expect.objectContaining({
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'Symptom log not found',
+        path: '/api/symptom-logs/x',
+      }),
+    )
+  })
+
+  it('maps an unknown error to a generic 500 without leaking internals', () => {
+    filter.catch(new Error('DB password is hunter2'), host())
+
+    const [, body, status] = reply.mock.calls[0]
+    expect(status).toBe(500)
+    expect(body.message).toBe('Internal server error')
+    expect(JSON.stringify(body)).not.toContain('hunter2')
+  })
+
+  it('keeps the original status for other HttpExceptions (403)', () => {
+    filter.catch(new ForbiddenException('Not your patient'), host())
+
+    const [, body, status] = reply.mock.calls[0]
+    expect(status).toBe(403)
+    expect(body.message).toBe('Not your patient')
+  })
+})

--- a/apps/api/src/common/all-exceptions.filter.ts
+++ b/apps/api/src/common/all-exceptions.filter.ts
@@ -1,0 +1,64 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common'
+import { HttpAdapterHost } from '@nestjs/core'
+
+/**
+ * Catch-all exception filter: normalizes every error response to a consistent
+ * shape, preserves HttpException status/messages, maps unknown errors to a
+ * generic 500 (so internals never leak to clients), and logs the real cause of
+ * unhandled errors with a stack trace. Registered globally via APP_FILTER.
+ */
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  private readonly logger = new Logger('ExceptionsFilter')
+
+  constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const { httpAdapter } = this.httpAdapterHost
+    const ctx = host.switchToHttp()
+    const request = ctx.getRequest()
+    const path = httpAdapter.getRequestUrl(request)
+
+    const isHttp = exception instanceof HttpException
+    const status = isHttp ? exception.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR
+
+    let message: string | string[]
+    let error: string
+    if (isHttp) {
+      const res = exception.getResponse()
+      if (typeof res === 'string') {
+        message = res
+        error = exception.name
+      } else {
+        const r = res as { message?: string | string[]; error?: string }
+        message = r.message ?? exception.message
+        error = r.error ?? exception.name
+      }
+    } else {
+      // Don't leak internal error details to the client.
+      message = 'Internal server error'
+      error = 'InternalServerError'
+    }
+
+    // HttpExceptions are expected control flow; only log the unexpected ones.
+    if (!isHttp) {
+      this.logger.error(
+        `Unhandled exception on ${path}`,
+        exception instanceof Error ? exception.stack : String(exception),
+      )
+    }
+
+    httpAdapter.reply(
+      ctx.getResponse(),
+      { statusCode: status, error, message, path, timestamp: new Date().toISOString() },
+      status,
+    )
+  }
+}

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+// App Router error boundary: catches uncaught render/runtime errors in any
+// route segment and shows a graceful fallback with a reset, instead of a blank
+// screen. `reset()` re-renders the segment to recover without a full reload.
+import { useEffect } from 'react'
+import ErrorState from '@/components/ErrorState'
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error('[route error]', error)
+  }, [error])
+
+  return (
+    <main style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#f9fafb' }}>
+      <ErrorState
+        title="This page hit a snag"
+        message="We couldn't finish loading this view. You can retry, or head back home."
+        onRetry={reset}
+      />
+    </main>
+  )
+}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+// Last-resort boundary for errors thrown in the root layout itself. It replaces
+// the entire document, so it must render its own <html>/<body>. Kept minimal and
+// provider-free since the normal app shell is unavailable here.
+import { useEffect } from 'react'
+import ErrorState from '@/components/ErrorState'
+
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error('[global error]', error)
+  }, [error])
+
+  return (
+    <html lang="en">
+      <body style={{ margin: 0 }}>
+        <main style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#f9fafb' }}>
+          <ErrorState
+            title="The app ran into a problem"
+            message="Something went wrong while loading LunaSol. Please try again."
+            onRetry={reset}
+          />
+        </main>
+      </body>
+    </html>
+  )
+}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,14 @@
+// Graceful 404 for unknown routes (App Router `not-found` convention).
+import ErrorState from '@/components/ErrorState'
+
+export default function NotFound() {
+  return (
+    <main style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#f9fafb' }}>
+      <ErrorState
+        title="Page not found"
+        message="The page you're looking for doesn't exist or may have moved."
+        homeHref="/"
+      />
+    </main>
+  )
+}

--- a/apps/web/src/components/ErrorState.tsx
+++ b/apps/web/src/components/ErrorState.tsx
@@ -1,0 +1,69 @@
+import { AlertTriangle, RefreshCw } from 'lucide-react'
+
+/**
+ * Reusable, friendly error panel. Used by the App Router error boundaries and
+ * by any data view that wants to surface a load failure inline instead of a
+ * blank screen. Presentational only — pass `onRetry` to show a retry button.
+ */
+export default function ErrorState({
+  title = 'Something went wrong',
+  message = 'An unexpected error occurred. Please try again.',
+  onRetry,
+  homeHref = '/',
+  compact = false,
+}: {
+  title?: string
+  message?: string
+  onRetry?: () => void
+  homeHref?: string | null
+  compact?: boolean
+}) {
+  return (
+    <div
+      role="alert"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+        gap: '12px',
+        padding: compact ? '32px 20px' : '64px 24px',
+        fontFamily: "'Segoe UI', system-ui, sans-serif",
+        color: '#374151',
+      }}
+    >
+      <div style={{ display: 'inline-flex', padding: '12px', background: '#fef2f2', borderRadius: '12px' }}>
+        <AlertTriangle size={compact ? 24 : 32} color="#dc2626" />
+      </div>
+      <h2 style={{ fontSize: compact ? '16px' : '20px', fontWeight: 700, color: '#111827', margin: 0 }}>{title}</h2>
+      <p style={{ fontSize: '14px', color: '#6b7280', margin: 0, maxWidth: '420px', lineHeight: 1.6 }}>{message}</p>
+      <div style={{ display: 'flex', gap: '10px', marginTop: '4px', flexWrap: 'wrap', justifyContent: 'center' }}>
+        {onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            style={{
+              display: 'inline-flex', alignItems: 'center', gap: '8px',
+              padding: '10px 18px', borderRadius: '8px', border: 'none',
+              background: '#10b981', color: '#ffffff', fontSize: '14px', fontWeight: 700, cursor: 'pointer',
+            }}
+          >
+            <RefreshCw size={15} /> Try again
+          </button>
+        )}
+        {homeHref && (
+          <a
+            href={homeHref}
+            style={{
+              display: 'inline-flex', alignItems: 'center',
+              padding: '10px 18px', borderRadius: '8px', border: '1px solid #d1d5db',
+              background: '#ffffff', color: '#374151', fontSize: '14px', fontWeight: 600, textDecoration: 'none',
+            }}
+          >
+            Go home
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4,18 +4,34 @@ export async function apiFetch(
 ) {
   const { token, headers, ...rest } = options
 
-  const res = await fetch(`/api${path}`, {
-    ...rest,
-    headers: {
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...headers,
-    },
-  })
+  let res: Response
+  try {
+    res = await fetch(`/api${path}`, {
+      ...rest,
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...headers,
+      },
+    })
+  } catch {
+    // fetch() only rejects on network-level failures (offline, DNS, aborted).
+    // Surface a human message instead of a raw "Failed to fetch".
+    throw new Error('Network error — please check your connection and try again.')
+  }
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}))
     throw new Error(body.message || `API error ${res.status}`)
   }
 
-  return res.json()
+  // Tolerate empty / non-JSON success responses (e.g. 204 No Content) so
+  // callers that don't expect a body don't blow up on res.json().
+  if (res.status === 204) return null
+  const text = await res.text()
+  if (!text) return null
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
 }


### PR DESCRIPTION
Closes #98
Closes #100

Makes errors degrade gracefully across all three runtimes instead of white-screening, leaking internals, or failing silently.

## Web (`apps/web`) — #98
**App Router error boundaries (catch-all safety net)**
- `app/error.tsx` — segment boundary; catches uncaught render/runtime errors (and throwing server-component fetches) with a `reset()` retry.
- `app/global-error.tsx` — last-resort boundary for root-layout failures (renders its own `<html>/<body>`).
- `app/not-found.tsx` — friendly 404.
- `components/ErrorState.tsx` — shared presentational error panel (icon + message + optional retry/home), inline-style + lucide conventions, `role="alert"`.

**`apiFetch` hardening (shared data path for ~19 callers)**
- `fetch()` network rejections → human-readable *"Network error…"* instead of raw `TypeError: Failed to fetch`.
- `204` / empty / non-JSON success responses return `null` instead of crashing on `res.json()`.

## API (`apps/api`, NestJS) — #100
- **Global exception filter** (`common/all-exceptions.filter.ts`, registered via `APP_FILTER`): normalizes every error body to `{ statusCode, error, message, path, timestamp }`, preserves `HttpException` status/messages, maps unknown errors to a generic 500 (no internals leaked), and logs unhandled errors with a stack. Unit spec included.

## AI service (`apps/ai`, FastAPI) — #100
- **Global exception handler**: sanitized 500 response + server-side `logging.exception`.
- **SSE streams** (`triage.py`) no longer emit raw `str(e)` to the client — they send a generic `error` event while logging the real cause.

## Verification
- `apps/web` `tsc --noEmit` clean; web lint clean (only a pre-existing unrelated `any` warning).
- `apps/api` `tsc --noEmit` clean; `pnpm --filter @lunasol/api test` — **103 passing** (incl. the new filter spec).
- `apps/ai` `python -m py_compile` clean (no venv in CI worktree to run pytest; existing `test_main.py` endpoints unchanged).

## Follow-ups (tracked in #98, not in this PR)
Replace blocking `alert()` error UX with a non-blocking toast/inline pattern, give every data view an explicit error+retry state, and audit swallowed `catch {}` blocks.