### PR TITLE
chore(seed): enrich demo seed to full parity; tidy dev seed

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -254,14 +254,13 @@ async function main() {
   console.log('  + Creating confirmed appointments …');
 
   // Find open future slots for first 3 doctors (take 1st available slot each)
-  const confirmedAppointments = [];
   for (let i = 0; i < 3; i++) {
     const doctorSlots = allSlots.filter(
       (s) => s.doctorId === doctorProfiles[i]!.id && !s.isBlocked,
     );
     const slot = doctorSlots[0]!;
 
-    const appointment = await prisma.appointment.create({
+    await prisma.appointment.create({
       data: {
         patientId: patientProfiles[i]!.id,
         doctorId: doctorProfiles[i]!.id,
@@ -270,7 +269,6 @@ async function main() {
         livekitRoom: `appt-${doctorProfiles[i]!.id.slice(-6)}-${patientProfiles[i]!.id.slice(-6)}`,
       },
     });
-    confirmedAppointments.push(appointment);
   }
 
   // ── 6. Create completed appointments (past) + consultation records ──────
@@ -333,7 +331,7 @@ async function main() {
   ];
 
   for (let i = 0; i < 3; i++) {
-    const appointment = await prisma.appointment.create({
+    await prisma.appointment.create({
       data: {
         patientId: patientProfiles[i]!.id,
         doctorId: doctorProfiles[i]!.id,

--- a/scripts/seed-demo.js
+++ b/scripts/seed-demo.js
@@ -1,5 +1,6 @@
 // Idempotent demo seed: creates real Clerk accounts (email + password + role)
-// and matching complete DB profiles + availability. Safe to re-run.
+// and matching complete DB profiles + availability + appointments, consultation
+// records, prescriptions and notifications. Safe to re-run.
 // Run inside the prod api container (has @prisma/client, @clerk/backend,
 // DATABASE_URL and CLERK_SECRET_KEY).
 const { PrismaClient } = require('@prisma/client')
@@ -57,9 +58,64 @@ const PATIENTS = [
   },
 ]
 
+// One completed consultation per patient↔doctor pair (index-aligned with the
+// arrays above). Notes + prescriptions are specialization-appropriate.
+const CONSULTATIONS = [
+  {
+    notes:
+      'Patient presented with persistent dry cough for 2 weeks. Lungs clear on auscultation. Likely post-nasal drip secondary to allergic rhinitis. Advised saline nasal rinse and follow-up in 2 weeks if symptoms persist.',
+    prescriptions: [
+      {
+        medicationName: 'Cetirizine',
+        dosage: '10mg',
+        frequency: 'Once daily at bedtime',
+        duration: '14 days',
+        notes: 'Take with water. May cause drowsiness.',
+      },
+      {
+        medicationName: 'Fluticasone Nasal Spray',
+        dosage: '50mcg/spray, 2 sprays per nostril',
+        frequency: 'Once daily in the morning',
+        duration: '30 days',
+        notes: 'Shake well before use. Avoid spraying towards nasal septum.',
+      },
+    ],
+  },
+  {
+    notes:
+      'Routine cardiac follow-up. Blood pressure 130/85 mmHg. ECG shows normal sinus rhythm. Lipid panel results reviewed — LDL slightly elevated at 140 mg/dL. Lifestyle modifications discussed. Consider statin therapy at next visit if no improvement.',
+    prescriptions: [
+      {
+        medicationName: 'Losartan',
+        dosage: '50mg',
+        frequency: 'Once daily in the morning',
+        duration: '90 days',
+        notes: 'Continue current dose. Monitor blood pressure weekly.',
+      },
+    ],
+  },
+]
+
 const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY })
 const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL })
 const prisma = new PrismaClient({ adapter: new PrismaPg(pool) })
+
+// ─── Date helpers ───────────────────────────────────────────────────────────
+
+/** A Date `days` from now at the given UTC hour. */
+function futureDate(days, hour) {
+  const d = new Date()
+  d.setUTCDate(d.getUTCDate() + days)
+  d.setUTCHours(hour, 0, 0, 0)
+  return d
+}
+
+/** A Date `days` in the past at the given UTC hour. */
+function pastDate(days, hour) {
+  return futureDate(-days, hour)
+}
+
+// ─── Clerk ──────────────────────────────────────────────────────────────────
 
 async function ensureClerkUser(acct, role) {
   const existing = await clerk.users.getUserList({ emailAddress: [acct.email] })
@@ -82,14 +138,14 @@ async function ensureClerkUser(acct, role) {
   return user.id
 }
 
+// ─── Idempotent DB helpers ──────────────────────────────────────────────────
+
 function slotsForDoctor() {
   // 3 x 30-min slots/day at 09:00/10:00/11:00 UTC for the next 7 days.
   const slots = []
   for (let day = 1; day <= 7; day++) {
     for (const hour of [9, 10, 11]) {
-      const start = new Date()
-      start.setUTCDate(start.getUTCDate() + day)
-      start.setUTCHours(hour, 0, 0, 0)
+      const start = futureDate(day, hour)
       const end = new Date(start)
       end.setUTCMinutes(30)
       slots.push({ startTime: start, endTime: end })
@@ -98,7 +154,61 @@ function slotsForDoctor() {
   return slots
 }
 
+/** Find (or create) a slot for a doctor at a specific start time. */
+async function ensureSlotAt(doctorId, startTime, endTime, isBlocked = false) {
+  const existing = await prisma.availabilitySlot.findFirst({
+    where: { doctorId, startTime },
+  })
+  if (existing) return existing
+  return prisma.availabilitySlot.create({
+    data: { doctorId, startTime, endTime, isBlocked },
+  })
+}
+
+/** Upsert an appointment keyed by its (unique) slot. */
+function ensureAppointment(slotId, data) {
+  return prisma.appointment.upsert({
+    where: { slotId },
+    update: data,
+    create: { slotId, ...data },
+  })
+}
+
+/** Upsert a consultation record (keyed by its unique appointment) and replace
+ *  its prescriptions so re-runs stay deterministic. */
+async function ensureConsultationRecord(appointmentId, notes, prescriptions) {
+  const record = await prisma.consultationRecord.upsert({
+    where: { appointmentId },
+    update: { notes },
+    create: { appointmentId, notes },
+  })
+  await prisma.prescription.deleteMany({ where: { consultationRecordId: record.id } })
+  await prisma.prescription.createMany({
+    data: prescriptions.map((p) => ({ ...p, consultationRecordId: record.id })),
+  })
+  return record
+}
+
+/** Create a notification only if an identical one doesn't already exist. */
+async function ensureNotification({ recipientId, type, message, isRead }) {
+  const existing = await prisma.notification.findFirst({
+    where: { recipientId, type, message },
+  })
+  if (existing) return existing
+  return prisma.notification.create({
+    data: { recipientId, type, message, isRead },
+  })
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
 async function main() {
+  const doctorProfiles = []
+  const doctorUsers = []
+  const patientProfiles = []
+  const patientUsers = []
+
+  // ── Doctors ───────────────────────────────────────────────────────────────
   for (const acct of DOCTORS) {
     console.log(`Doctor: ${acct.name}`)
     const clerkId = await ensureClerkUser(acct, 'doctor')
@@ -121,8 +231,11 @@ async function main() {
     } else {
       console.log(`  already has ${slotCount} slots, skipping`)
     }
+    doctorProfiles.push(profile)
+    doctorUsers.push(user)
   }
 
+  // ── Patients ──────────────────────────────────────────────────────────────
   for (const acct of PATIENTS) {
     console.log(`Patient: ${acct.name}`)
     const clerkId = await ensureClerkUser(acct, 'patient')
@@ -131,14 +244,128 @@ async function main() {
       update: { email: acct.email, role: 'PATIENT' },
       create: { clerkId, email: acct.email, role: 'PATIENT' },
     })
-    await prisma.patientProfile.upsert({
+    const profile = await prisma.patientProfile.upsert({
       where: { userId: user.id },
       update: { name: acct.name, birthday: acct.birthday, weight: acct.weight, height: acct.height, phone: acct.phone, address: acct.address, medicalHistory: acct.medicalHistory },
       create: { userId: user.id, name: acct.name, birthday: acct.birthday, weight: acct.weight, height: acct.height, phone: acct.phone, address: acct.address, medicalHistory: acct.medicalHistory },
     })
+    patientProfiles.push(profile)
+    patientUsers.push(user)
   }
 
-  console.log('\nDemo seed complete.')
+  // ── Confirmed (upcoming) appointments ───────────────────────────────────────
+  // Pair patient[i] ↔ doctor[i] on a deterministic future slot (day 1, 10:00).
+  console.log('Confirmed appointments:')
+  for (let i = 0; i < PATIENTS.length; i++) {
+    const start = futureDate(1, 10)
+    const end = new Date(start)
+    end.setUTCMinutes(30)
+    const slot = await ensureSlotAt(doctorProfiles[i].id, start, end)
+    await ensureAppointment(slot.id, {
+      patientId: patientProfiles[i].id,
+      doctorId: doctorProfiles[i].id,
+      status: 'CONFIRMED',
+      livekitRoom: `appt-${doctorProfiles[i].id.slice(-6)}-${patientProfiles[i].id.slice(-6)}`,
+    })
+    console.log(`  ${PATIENTS[i].name} → ${DOCTORS[i].name}`)
+  }
+
+  // ── Completed (past) appointments + records + prescriptions ─────────────────
+  console.log('Completed consultations:')
+  for (let i = 0; i < PATIENTS.length; i++) {
+    const start = pastDate(7 - i, 10)
+    const end = new Date(start)
+    end.setUTCHours(11, 0, 0, 0)
+    const slot = await ensureSlotAt(doctorProfiles[i].id, start, end)
+    const appointment = await ensureAppointment(slot.id, {
+      patientId: patientProfiles[i].id,
+      doctorId: doctorProfiles[i].id,
+      status: 'COMPLETED',
+      livekitRoom: `appt-past-${i + 1}`,
+    })
+    await ensureConsultationRecord(
+      appointment.id,
+      CONSULTATIONS[i].notes,
+      CONSULTATIONS[i].prescriptions,
+    )
+    console.log(`  ${PATIENTS[i].name} with ${DOCTORS[i].name} (${CONSULTATIONS[i].prescriptions.length} Rx)`)
+  }
+
+  // ── Notifications ───────────────────────────────────────────────────────────
+  console.log('Notifications:')
+  const notifications = [
+    // Patient notifications
+    {
+      recipientId: patientUsers[0].id,
+      type: 'APPOINTMENT_CONFIRMED',
+      message: `Your appointment with ${DOCTORS[0].name} has been confirmed.`,
+      isRead: false,
+    },
+    {
+      recipientId: patientUsers[0].id,
+      type: 'CONSULTATION_COMPLETE',
+      message: `${DOCTORS[0].name} has completed your consultation. View your records and prescriptions.`,
+      isRead: true,
+    },
+    {
+      recipientId: patientUsers[0].id,
+      type: 'PRESCRIPTION_ISSUED',
+      message: 'A new prescription has been issued for you. Check your medical records.',
+      isRead: true,
+    },
+    {
+      recipientId: patientUsers[1].id,
+      type: 'APPOINTMENT_CONFIRMED',
+      message: `Your appointment with ${DOCTORS[1].name} has been confirmed.`,
+      isRead: false,
+    },
+    {
+      recipientId: patientUsers[1].id,
+      type: 'CONSULTATION_COMPLETE',
+      message: `${DOCTORS[1].name} has completed your consultation. View your records and prescriptions.`,
+      isRead: false,
+    },
+    // Doctor notifications
+    {
+      recipientId: doctorUsers[0].id,
+      type: 'NEW_APPOINTMENT',
+      message: `New appointment booked by ${PATIENTS[0].name}.`,
+      isRead: true,
+    },
+    {
+      recipientId: doctorUsers[0].id,
+      type: 'APPOINTMENT_REMINDER',
+      message: 'Reminder: You have an upcoming appointment tomorrow at 10:00 AM.',
+      isRead: false,
+    },
+    {
+      recipientId: doctorUsers[1].id,
+      type: 'NEW_APPOINTMENT',
+      message: `New appointment booked by ${PATIENTS[1].name}.`,
+      isRead: false,
+    },
+  ]
+  for (const n of notifications) {
+    await ensureNotification(n)
+  }
+  console.log(`  ensured ${notifications.length} notifications`)
+
+  // ── Summary ─────────────────────────────────────────────────────────────────
+  const counts = {
+    users: await prisma.user.count(),
+    doctorProfiles: await prisma.doctorProfile.count(),
+    patientProfiles: await prisma.patientProfile.count(),
+    availabilitySlots: await prisma.availabilitySlot.count(),
+    appointments: await prisma.appointment.count(),
+    consultationRecords: await prisma.consultationRecord.count(),
+    prescriptions: await prisma.prescription.count(),
+    notifications: await prisma.notification.count(),
+  }
+  console.log('\nDemo seed complete. Current totals:')
+  for (const [table, count] of Object.entries(counts)) {
+    console.log(`  ${table}: ${count}`)
+  }
+
   await prisma.$disconnect()
   await pool.end()
 }


### PR DESCRIPTION
## What

- **`scripts/seed-demo.js`** (production / Clerk-backed demo seed) — bring it up to full data parity with the dev seed. On top of the existing 2 doctors + 2 patients + availability slots it now also creates, **idempotently**:
  - 1 confirmed upcoming appointment per patient↔doctor pair
  - 1 completed past appointment with a consultation record + specialization-appropriate prescriptions (GP → Cetirizine/Fluticasone, Cardiology → Losartan)
  - per-user notifications
- **`apps/api/prisma/seed.ts`** (local-dev seed) — tidy in place: removed the dead `confirmedAppointments` array and the unused `appointment` locals. **No behavior change.**

## Why

The Clerk Production demo accounts (`*@lunasoldemo.com`) had profiles + slots but no history, so the app looked empty on open. This populates an upcoming visit, a past consultation with prescriptions, and notifications for a fuller demo.

## Idempotency

All new writes are safe to re-run: `upsert` on unique keys (`slotId`, `appointmentId`, `userId`, `clerkId`), prescriptions replaced deterministically per record, and notifications guarded by `findFirst`-then-create. No new Clerk accounts are created (same 2 doctors + 2 patients).

## Testing

- `node --check scripts/seed-demo.js` clean.
- Ran the enriched `seed-demo.js` **twice** against a DB (Clerk stubbed): run 1 adds the data, run 2 produces **identical** counts — no duplicates.
- Re-ran the dev `seed.ts` after the cleanup → identical record counts (behavior-neutral).