### PR TITLE
fix: sync pnpm-lock.yaml with @playwright/test root dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@prisma/client':
         specifier: ^7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)


### PR DESCRIPTION
## Problem
The prod deploy ([run 26686474754](https://github.com/Benny-Gil/LunaSol/actions/runs/26686474754)) failed at **Build images** with:

```
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with package.json
* 1 dependencies were added: @playwright/test@^1.60.0
```

The root `package.json` declares `@playwright/test@^1.60.0`, but the matching `pnpm-lock.yaml` entry was never committed. The Docker prod build forces `--frozen-lockfile`, so it refuses to install.

## Fix
Commit the lockfile update so it matches `package.json`. Verified locally: `pnpm install --frozen-lockfile` passes ("Already up to date").

## Follow-up
Once merged, promote `main` → `prod` to re-run the deploy.