### PR TITLE
release: sync pnpm-lock.yaml to fix prod deploy

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@prisma/client':
         specifier: ^7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)


### PR DESCRIPTION
## Release

Promotes `main` → `prod` to fix the broken production deploy.

The previous promotion's deploy ([run 26686474754](https://github.com/Benny-Gil/LunaSol/actions/runs/26686474754)) failed at **Build images** with `ERR_PNPM_OUTDATED_LOCKFILE` — the root `package.json` declared `@playwright/test@^1.60.0` but `pnpm-lock.yaml` was never updated.

This release carries #104, which commits the missing lockfile entry. Verified `pnpm install --frozen-lockfile` passes.

### Commits
- 9f65b47 fix: sync pnpm-lock.yaml with @playwright/test root dependency

No Prisma migrations in this release.