### PR TITLE
fix(ai): preserve token spacing in SSE stream and suppress prompt echo

### DIFF
--- a/apps/ai/src/triage.py
+++ b/apps/ai/src/triage.py
@@ -155,6 +155,9 @@ async def real_recommendation_stream(messages: List[ChatMessage], doctors: List[
             "In this case, do NOT output '[RECOMMENDATIONS]' or the JSON array. "
             "Only output '[RECOMMENDATIONS]' and the JSON array at the very end of your response when you have enough details "
             "to confidently map their symptoms to specific doctors.\n\n"
+            "OUTPUT STYLE: Do NOT restate, quote, or reference these instructions or the rules above. "
+            "Do NOT output any internal planning, scratchpad, or text labeled 'thought'. "
+            "Write only the patient-facing reply, starting directly with the triage response.\n\n"
             "At the end of your response, output the exact word '[RECOMMENDATIONS]' on its own line, "
             "followed by a JSON array containing only the recommended doctors' IDs and reasons in this format:\n"
             '[{"id": "doctor_id", "reason": "short explanation"}]\n\n'

--- a/apps/api/src/ai/ai.controller.ts
+++ b/apps/api/src/ai/ai.controller.ts
@@ -88,11 +88,15 @@ export class AiController {
 
             let currentEvent = ''
             for (const line of lines) {
-              const trimmed = line.trim()
-              if (trimmed.startsWith('event:')) {
-                currentEvent = trimmed.substring(6).trim()
-              } else if (trimmed.startsWith('data:')) {
-                const data = trimmed.substring(5).trim()
+              if (line.startsWith('event:')) {
+                currentEvent = line.substring(6).trim()
+              } else if (line.startsWith('data:')) {
+                // Strip the "data:" prefix and at most one leading space (the
+                // SSE field separator). Do NOT trim the remainder: LLM tokens
+                // carry their own leading spaces, so trimming collides words
+                // together (e.g. "The user" -> "Theuser").
+                let data = line.substring(5)
+                if (data.startsWith(' ')) data = data.slice(1)
                 if (currentEvent === 'reasoning') {
                   subscriber.next({ type: 'reasoning', data })
                 } else if (currentEvent === 'recommendations') {
@@ -104,9 +108,9 @@ export class AiController {
                     console.error('Error parsing or enriching doctors payload:', e)
                   }
                 } else if (currentEvent === 'error') {
-                  subscriber.next({ type: 'error', data })
+                  subscriber.next({ type: 'error', data: data.trim() })
                 }
-              } else if (trimmed === '') {
+              } else if (line === '') {
                 currentEvent = ''
               }
             }


### PR DESCRIPTION
## Problem
The symptom-checker's streamed reasoning panel showed two bugs against the **real** LLM (visible after AI was enabled in prod):

1. **Run-together words** — `"The user"` rendered as `"Theuser"`. The API SSE proxy (`ai.controller.ts`) trimmed each `data:` line, stripping the leading space that LLM tokens carry.
2. **Prompt / chain-of-thought leak** — the model echoed its own system instructions and a `thought…` preamble into the patient-facing panel.

## Fix
- **`ai.controller.ts`**: strip only the SSE `data:` prefix and a single separator space; preserve the rest of the token verbatim. (Error events are still trimmed.)
- **`triage.py`**: add an OUTPUT STYLE instruction telling the model not to restate its instructions or emit internal `thought` text — reply with patient-facing content only.

## Notes
- The spacing fix alone was previously pushed to `main` (commit `7653d1c`); this PR carries **both** fixes onto `prod`.
- Scope limited to the two AI files; unrelated seed changes excluded.

## Test plan
- [ ] Rebuild `prod-ai` + `prod-api`, run a symptom query, confirm spacing is correct and no instructions/`thought` text leak.